### PR TITLE
Make Value take a pointer receiver

### DIFF
--- a/decimal.go
+++ b/decimal.go
@@ -495,7 +495,10 @@ func (d *Decimal) Scan(value interface{}) error {
 }
 
 // Value implements the driver.Valuer interface for database serialization.
-func (d Decimal) Value() (driver.Value, error) {
+func (d *Decimal) Value() (driver.Value, error) {
+	if d == nil {
+		return nil, nil
+	}
 	return d.String(), nil
 }
 

--- a/decimal_test.go
+++ b/decimal_test.go
@@ -874,6 +874,27 @@ func TestDecimal_Scan(t *testing.T) {
 	}
 }
 
+func TestDecimal_Value(t *testing.T) {
+	// check that nil is handled appropriately
+	var decimalPtr *Decimal
+	value, err := decimalPtr.Value()
+	if err != nil {
+		t.Errorf("(*Decimal)(<nil>) failed with message: %s", err)
+	} else if value != nil {
+		t.Errorf("%v is not nil", value)
+	}
+
+	// check that normal case is handled appropriately
+	a := New(1234, 2)
+	expected := "123400"
+	value, err = a.Value()
+	if err != nil {
+		t.Errorf("Decimal(123400).Value() failed with message: %s", err)
+	} else if value.(string) != expected {
+		t.Errorf("%s does not equal to %s", a, expected)
+	}
+}
+
 // old tests after this line
 
 func TestDecimal_Scale(t *testing.T) {


### PR DESCRIPTION
The `Value` method needs to take a pointer receiver so that null values can be inserted into the database with ease.

This PR shouldn't affect any existing behavior since the arguments to `Exec` get converted into an `interface{}`.