### PR TITLE
Added implementation of DigitsValue() that exposes the big.Int value part of the decimal.

### DIFF
--- a/decimal.go
+++ b/decimal.go
@@ -532,6 +532,16 @@ func (d Decimal) MarshalText() (text []byte, err error) {
 	return []byte(d.String()), nil
 }
 
+// GobDecode implements the gob.GobDecoder interface for gob serialization.
+func (d *Decimal) GobDecode(data []byte) error {
+	return d.UnmarshalText(data)
+}
+
+// GobEncode implements the gob.GobEncoder interface for gob serialization.
+func (d Decimal) GobEncode() ([]byte, error) {
+	return d.MarshalText()
+}
+
 // NOTE: buggy, unintuitive, and DEPRECATED! Use StringFixed instead.
 // StringScaled first scales the decimal then calls .String() on it.
 func (d Decimal) StringScaled(exp int32) string {

--- a/decimal.go
+++ b/decimal.go
@@ -313,6 +313,12 @@ func (d Decimal) Equals(d2 Decimal) bool {
 	return d.Cmp(d2) == 0
 }
 
+// DigitsValue returns the integer that represents the digits of the decimal.
+// This is the value of the decimal scaled by 10^Exponent().
+func (d Decimal) DigitsValue() *big.Int {
+	return d.value
+}
+
 // Exponent returns the exponent, or scale component of the decimal.
 func (d Decimal) Exponent() int32 {
 	return d.exp

--- a/decimal_test.go
+++ b/decimal_test.go
@@ -885,6 +885,13 @@ func TestDecimal_Scale(t *testing.T) {
 	}
 }
 
+func TestDecimal_DigitsValue(t *testing.T) {
+	a := New(1234, -3)
+	if a.DigitsValue().Int64() != 1234 {
+		t.Errorf("error")
+	}
+}
+
 func TestDecimal_Abs1(t *testing.T) {
 	a := New(-1234, -4)
 	b := New(1234, -4)


### PR DESCRIPTION
The current API exposes the Exponent but not the underlying big.Int(). This caused me some needless pain with constructing a bridge to another implementation of decimals that also uses an integer and an exponent underneath.
