### PR TITLE
Handle strings being passed to Scan()

### DIFF
--- a/decimal.go
+++ b/decimal.go
@@ -638,8 +638,14 @@ func round(n float64) int64 {
 }
 
 func unquoteIfQuoted(value interface{}) (string, error) {
-	bytes, ok := value.([]byte)
-	if !ok {
+	var bytes []byte
+
+	switch v := value.(type) {
+	case string:
+		bytes = []byte(v)
+	case []byte:
+		bytes = v
+	default:
 		return "", fmt.Errorf("Could not convert value '%+v' to byte array",
 			value)
 	}

--- a/decimal_test.go
+++ b/decimal_test.go
@@ -849,7 +849,7 @@ func TestDecimal_Max(t *testing.T) {
 }
 
 func TestDecimal_Scan(t *testing.T) {
-	// test the Scan method the implements the
+	// test the Scan method that implements the
 	// sql.Scanner interface
 	// check for the for different type of values
 	// that are possible to be received from the database
@@ -895,12 +895,32 @@ func TestDecimal_Scan(t *testing.T) {
 	value_str := "535.666"
 	dbvalue_str := []byte(value_str)
 	expected, err = NewFromString(value_str)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	err = a.Scan(dbvalue_str)
 	if err != nil {
 		// Scan failed... no need to test result value
 		t.Errorf("a.Scan('535.666') failed with message: %s", err)
 
+	} else {
+		// Scan suceeded... test resulting values
+		if !a.Equals(expected) {
+			t.Errorf("%s does not equal to %s", a, expected)
+		}
+	}
+
+	// lib/pq can also return strings
+	expected, err = NewFromString(value_str)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = a.Scan(value_str)
+	if err != nil {
+		// Scan failed... no need to test result value
+		t.Errorf("a.Scan('535.666') failed with message: %s", err)
 	} else {
 		// Scan suceeded... test resulting values
 		if !a.Equals(expected) {


### PR DESCRIPTION
lib/pq can now pass strings to Scan() as of:
https://github.com/lib/pq/commit/e2402a7cd1e57e08a576b94cdfed36ae30366545