### PR TITLE
Handle float32 in Scan method

### DIFF
--- a/decimal.go
+++ b/decimal.go
@@ -524,10 +524,7 @@ func (d *Decimal) Scan(value interface{}) (err error) {
 }
 
 // Value implements the driver.Valuer interface for database serialization.
-func (d *Decimal) Value() (driver.Value, error) {
-	if d == nil {
-		return nil, nil
-	}
+func (d Decimal) Value() (driver.Value, error) {
 	return d.String(), nil
 }
 

--- a/decimal.go
+++ b/decimal.go
@@ -494,9 +494,12 @@ func (d Decimal) MarshalJSON() ([]byte, error) {
 }
 
 // Scan implements the sql.Scanner interface for database deserialization.
-func (d *Decimal) Scan(value interface{}) error {
+func (d *Decimal) Scan(value interface{}) (err error) {
 	// first try to see if the data is stored in database as a Numeric datatype
 	switch v := value.(type) {
+	case float32:
+		*d = NewFromFloat(float64(v))
+		return nil
 
 	case float64:
 		// numeric in sqlite3 sends us float64
@@ -662,8 +665,8 @@ func unquoteIfQuoted(value interface{}) (string, error) {
 	case []byte:
 		bytes = v
 	default:
-		return "", fmt.Errorf("Could not convert value '%+v' to byte array",
-			value)
+		return "", fmt.Errorf("Could not convert value '%+v' to byte array of type '%T'",
+			value, value)
 	}
 
 	// If the amount is quoted, strip the quotes


### PR DESCRIPTION
Using MySQL version 5.7.16 and github.com/go-sql-driver/mysql the float type is coming back as a float32 which is not currently handled in the Scan method.