### PR TITLE
Fix GobDecode

### DIFF
--- a/decimal.go
+++ b/decimal.go
@@ -697,7 +697,7 @@ func (d Decimal) GobEncode() ([]byte, error) {
 }
 
 // GobDecode implements the gob.GobDecoder interface for gob serialization.
-func (d Decimal) GobDecode(data []byte) error {
+func (d *Decimal) GobDecode(data []byte) error {
 	return d.UnmarshalBinary(data)
 }
 

--- a/decimal_test.go
+++ b/decimal_test.go
@@ -1637,5 +1637,10 @@ func TestGobEncode(t *testing.T) {
 		if eq != true {
 			t.Errorf("Encoding then decoding mutated Decimal")
 		}
+
+		eq = d1.Equal(d3)
+		if eq != true {
+			t.Errorf("Error gobencoding/decoding %v, got %v", d1, d3)
+		}
 	}
 }


### PR DESCRIPTION
This commit fixes GobDecode, which were mutating a copy of the receiver, rather than the intended pointed struct.

Without the fix, the new assertion fails with the following output:

```
--- FAIL: TestGobEncode (0.00s)
	decimal_test.go:1643: Error gobencoding/decoding 0.000000000000000001, got 0
	decimal_test.go:1643: Error gobencoding/decoding -0.111111111111111, got 0
	decimal_test.go:1643: Error gobencoding/decoding -3.141592653589793, got 0
	decimal_test.go:1643: Error gobencoding/decoding 1234567890123456000, got 0
	decimal_test.go:1643: Error gobencoding/decoding 0.1111111111111119, got 0
	decimal_test.go:1643: Error gobencoding/decoding 0.1000000000000008, got 0
	decimal_test.go:1643: Error gobencoding/decoding -0.000000000000000001, got 0
	decimal_test.go:1643: Error gobencoding/decoding -0.000000000000000005, got 0
	decimal_test.go:1643: Error gobencoding/decoding -1234.567890123456, got 0
	decimal_test.go:1643: Error gobencoding/decoding 3.141592653589793, got 0
	decimal_test.go:1643: Error gobencoding/decoding 3, got 0
	decimal_test.go:1643: Error gobencoding/decoding -0.000000000000000003, got 0
	decimal_test.go:1643: Error gobencoding/decoding -0.1000000000000001, got 0
	decimal_test.go:1643: Error gobencoding/decoding -10000000000000000000000000, got 0
	decimal_test.go:1643: Error gobencoding/decoding -0.1111111111111119, got 0
	decimal_test.go:1643: Error gobencoding/decoding -0.1000000000000008, got 0
	decimal_test.go:1643: Error gobencoding/decoding -0.000000000000000002, got 0
	decimal_test.go:1643: Error gobencoding/decoding 0.1234567890123456, got 0
	decimal_test.go:1643: Error gobencoding/decoding 0.1111111111111111, got 0
	decimal_test.go:1643: Error gobencoding/decoding -0.1000000000000002, got 0
	decimal_test.go:1643: Error gobencoding/decoding 0.1000000000000005, got 0
	decimal_test.go:1643: Error gobencoding/decoding -3, got 0
	decimal_test.go:1643: Error gobencoding/decoding -0.1000000000000005, got 0
	decimal_test.go:1643: Error gobencoding/decoding 1234567890123456, got 0
	decimal_test.go:1643: Error gobencoding/decoding 0.1000000000000002, got 0
	decimal_test.go:1643: Error gobencoding/decoding 0.1000000000000003, got 0
	decimal_test.go:1643: Error gobencoding/decoding 10000000000000000000000000, got 0
	decimal_test.go:1643: Error gobencoding/decoding -1234567890123456000, got 0
	decimal_test.go:1643: Error gobencoding/decoding 0.000000000000000003, got 0
	decimal_test.go:1643: Error gobencoding/decoding 0.1000000000000001, got 0
	decimal_test.go:1643: Error gobencoding/decoding 0.111111111111111, got 0
	decimal_test.go:1643: Error gobencoding/decoding 0.000000000000000005, got 0
	decimal_test.go:1643: Error gobencoding/decoding -0.1234567890123456, got 0
	decimal_test.go:1643: Error gobencoding/decoding -0.1111111111111111, got 0
	decimal_test.go:1643: Error gobencoding/decoding -0.000000000000000008, got 0
	decimal_test.go:1643: Error gobencoding/decoding 1234.567890123456, got 0
	decimal_test.go:1643: Error gobencoding/decoding 0.000000000000000008, got 0
	decimal_test.go:1643: Error gobencoding/decoding -0.1000000000000003, got 0
	decimal_test.go:1643: Error gobencoding/decoding 0.000000000000000002, got 0
	decimal_test.go:1643: Error gobencoding/decoding -1234567890123456, got 0
FAIL
FAIL	_/Users/basgys/Development/decimal	13.146s
```