### PR TITLE
Defensive Copy on Coefficient

### DIFF
--- a/decimal.go
+++ b/decimal.go
@@ -443,7 +443,9 @@ func (d Decimal) Exponent() int32 {
 
 // Coefficient returns the coefficient of the decimal.  It is scaled by 10^Exponent()
 func (d Decimal) Coefficient() *big.Int {
-	return d.value
+	// we copy the coefficient so that mutating the result does not mutate the
+	// Decimal.
+	return big.NewInt(0).Set(d.value)
 }
 
 // IntPart returns the integer component of the decimal.

--- a/decimal_test.go
+++ b/decimal_test.go
@@ -1421,6 +1421,10 @@ func TestDecimal_Coefficient(t *testing.T) {
 	if co.Int64() != 123 {
 		t.Error("Coefficient should be 123; Got:", co)
 	}
+	co.Set(big.NewInt(0))
+	if d.IntPart() != 123 {
+		t.Error("Modifying coefficient modified Decimal; Got:", d)
+	}
 }
 
 type DecimalSlice []Decimal


### PR DESCRIPTION
Currently, if someone gets the Coefficient, and then modifies the value in the pointer (which is easy to do with the weird way the `big` package works), then it will change the underlying decimal, which can be a very hard bug to track down.  This fixes that.