### PR TITLE
format usage code in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,30 +24,30 @@ Run `go get github.com/shopspring/decimal`
 package main
 
 import (
-    "fmt"
-    "github.com/shopspring/decimal"
+	"fmt"
+	"github.com/shopspring/decimal"
 )
 
 func main() {
 	price, err := decimal.NewFromString("136.02")
-    if err != nil {
-        panic(err)
-    }
+	if err != nil {
+		panic(err)
+	}
 
 	quantity := decimal.NewFromFloat(3)
 
 	fee, _ := decimal.NewFromString(".035")
 	taxRate, _ := decimal.NewFromString(".08875")
 
-    subtotal := price.Mul(quantity)
+	subtotal := price.Mul(quantity)
 
-    preTax := subtotal.Mul(fee.Add(decimal.NewFromFloat(1)))
+	preTax := subtotal.Mul(fee.Add(decimal.NewFromFloat(1)))
 
-    total := preTax.Mul(taxRate.Add(decimal.NewFromFloat(1)))
+	total := preTax.Mul(taxRate.Add(decimal.NewFromFloat(1)))
 
 	fmt.Println("Subtotal:", subtotal)                      // Subtotal: 408.06
 	fmt.Println("Pre-tax:", preTax)                         // Pre-tax: 422.3421
-    fmt.Println("Taxes:", total.Sub(preTax))                // Taxes: 37.482861375
+	fmt.Println("Taxes:", total.Sub(preTax))                // Taxes: 37.482861375
 	fmt.Println("Total:", total)                            // Total: 459.824961375
 	fmt.Println("Tax rate:", total.Sub(preTax).Div(preTax)) // Tax rate: 0.08875
 }


### PR DESCRIPTION
Usage codes in README are not well formatted.

Update it using gofmt.