### PR TITLE
RequireFromString

### DIFF
--- a/decimal.go
+++ b/decimal.go
@@ -153,6 +153,22 @@ func NewFromString(value string) (Decimal, error) {
 	}, nil
 }
 
+// RequireFromString returns a new Decimal from a string representation
+// or panics if NewFromString would have returned an error.
+//
+// Example:
+//
+//     d := RequireFromString("-123.45")
+//     d2 := RequireFromString(".0001")
+//
+func RequireFromString(value string) Decimal {
+	dec, err := NewFromString(value)
+	if err != nil {
+		panic(err)
+	}
+	return dec
+}
+
 // NewFromFloat converts a float64 to Decimal.
 //
 // Example:

--- a/decimal_test.go
+++ b/decimal_test.go
@@ -186,6 +186,41 @@ func TestNewFromStringDeepEquals(t *testing.T) {
 	}
 }
 
+func TestRequireFromString(t *testing.T) {
+	s := "1.23"
+	defer func() {
+		err := recover()
+		if err != nil {
+			t.Errorf("error while parsing %s", s)
+		}
+	}()
+
+	d := RequireFromString(s)
+	if d.String() != s {
+		t.Errorf("expected %s, got %s (%s, %d)",
+			s, d.String(),
+			d.value.String(), d.exp)
+	}
+}
+
+func TestRequireFromStringErrs(t *testing.T) {
+	s := "qwert"
+	var d Decimal
+	var err interface{}
+
+	func() {
+		defer func() {
+			err = recover()
+		}()
+
+		d = RequireFromString(s)
+	}()
+
+	if err == nil {
+		t.Errorf("panic expected when parsing %s", s)
+	}
+}
+
 func TestNewFromFloatWithExponent(t *testing.T) {
 	type Inp struct {
 		float float64


### PR DESCRIPTION
**Proposal**
decimal.RequireFromString which delegates to decimal.NewFromString and panics if an error was returned. Please rename the function to your liking, possibly to "MustParseFromString".

**Reasoning**
We often use decimal.NewFromString with string constants that are guaranteed to not cause errors. We should have the power to ignore the error scenario for string constants. The regexp package exposes [MustCompile](https://golang.org/pkg/regexp/#MustCompile) for the same reason.

**Why Not "Must"**
Another pattern is the "Must" pattern, such as [template.Must](https://golang.org/pkg/html/template/#Must). Not my preference, but one or the other could be in this library. Three lines of code here will save three per user of your library.