### PR TITLE
Fix broken RoundBank func in #75

### DIFF
--- a/decimal.go
+++ b/decimal.go
@@ -619,7 +619,8 @@ func (d Decimal) RoundBank(places int32) Decimal {
 	round := d.Round(places)
 	remainder := d.Sub(round).Abs()
 
-	if remainder.value.Cmp(fiveInt) == 0 && round.value.Bit(0) != 0 {
+	half := New(5, -places-1)
+	if remainder.Cmp(half) == 0 && round.value.Bit(0) != 0 {
 		if round.value.Sign() < 0 {
 			round.value.Add(round.value, oneInt)
 		} else {

--- a/decimal_test.go
+++ b/decimal_test.go
@@ -2108,3 +2108,24 @@ func TestAvg(t *testing.T) {
 		t.Errorf("Failed to calculate average, expected %s got %s", NewFromFloat(4.5).String(), avg.String())
 	}
 }
+
+func TestRoundBankAnomaly(t *testing.T) {
+	a := New(25, -1)
+	b := New(250, -2)
+
+	if !a.Equal(b) {
+		t.Errorf("Expected %s to equal %s", a, b)
+	}
+
+	expected := New(2, 0)
+
+	aRounded := a.RoundBank(0)
+	if !aRounded.Equal(expected) {
+		t.Errorf("Expected bank rounding %s to equal %s, but it was %s", a, expected, aRounded)
+	}
+
+	bRounded := b.RoundBank(0)
+	if !bRounded.Equal(expected) {
+		t.Errorf("Expected bank rounding %s to equal %s, but it was %s", b, expected, bRounded)
+	}
+}


### PR DESCRIPTION
This fixes the issue described in #75, wherein `RoundBank()` can return incorrect results for the same decimal value, varying based on the internal representation.