### PR TITLE
Added ensureInitialized() to the Neg() method

### DIFF
--- a/decimal.go
+++ b/decimal.go
@@ -278,6 +278,7 @@ func (d Decimal) Sub(d2 Decimal) Decimal {
 
 // Neg returns -d.
 func (d Decimal) Neg() Decimal {
+	d.ensureInitialized()
 	val := new(big.Int).Neg(d.value)
 	return Decimal{
 		value: val,

--- a/decimal_test.go
+++ b/decimal_test.go
@@ -936,6 +936,14 @@ func TestDecimal_Neg(t *testing.T) {
 	}
 }
 
+func TestDecimal_NegFromEmpty(t *testing.T) {
+	a := Decimal{}
+	b := a.Neg()
+	if b.String() != "0" {
+		t.Errorf("expected %s, got %s", "0", b)
+	}
+}
+
 func TestDecimal_Mul(t *testing.T) {
 	type Inp struct {
 		a string


### PR DESCRIPTION
When d.value is nil `Neg()` will panic. This change fixed it.