### PR TITLE
Optimize allocations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ go:
   - tip
 
 install:
-  - go build .
+  - go build -tags $(go version | awk '{ print $3 }') .
 
 script:
-  - go test -v
+  - go test -v -tags $(go version | awk '{ print $3 }')

--- a/decimal.go
+++ b/decimal.go
@@ -390,6 +390,15 @@ func (d Decimal) Abs() Decimal {
 
 // Add returns d + d2.
 func (d Decimal) Add(d2 Decimal) Decimal {
+	if d.exp == d2.exp {
+		d.ensureInitialized()
+		d2.ensureInitialized()
+		return Decimal{
+			value: new(big.Int).Add(d.value, d2.value),
+			exp:   d.exp,
+		}
+	}
+
 	baseScale := min(d.exp, d2.exp)
 	rd := d.rescale(baseScale)
 	rd2 := d2.rescale(baseScale)
@@ -403,6 +412,15 @@ func (d Decimal) Add(d2 Decimal) Decimal {
 
 // Sub returns d - d2.
 func (d Decimal) Sub(d2 Decimal) Decimal {
+	if d.exp == d2.exp {
+		d.ensureInitialized()
+		d2.ensureInitialized()
+		return Decimal{
+			value: new(big.Int).Sub(d.value, d2.value),
+			exp:   d.exp,
+		}
+	}
+
 	baseScale := min(d.exp, d2.exp)
 	rd := d.rescale(baseScale)
 	rd2 := d2.rescale(baseScale)

--- a/decimal_bench_test.go
+++ b/decimal_bench_test.go
@@ -1,0 +1,98 @@
+// +build !go1.2
+// +build !go1.3
+// +build !go1.4
+
+package decimal
+
+import (
+	"math/big"
+	"testing"
+)
+
+func Benchmark_decimal_Decimal_Add_different_precision(b *testing.B) {
+	d1 := NewFromFloat(1000.123)
+	d2 := NewFromFloat(500).Mul(NewFromFloat(0.12))
+
+	b.ReportAllocs()
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		d1.Add(d2)
+	}
+}
+
+func Benchmark_decimal_Decimal_Sub_different_precision(b *testing.B) {
+	d1 := NewFromFloat(1000.123)
+	d2 := NewFromFloat(500).Mul(NewFromFloat(0.12))
+
+	b.ReportAllocs()
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		d1.Sub(d2)
+	}
+}
+
+func Benchmark_math_big_Float_Sub_different_precision(b *testing.B) {
+	d1 := big.NewFloat(1000.123)
+	d2 := d1.Mul(big.NewFloat(500), big.NewFloat(0.12))
+
+	b.ReportAllocs()
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		d1.Sub(d1, d2)
+	}
+}
+
+func Benchmark_math_big_Float_Add_different_precision(b *testing.B) {
+	d1 := big.NewFloat(1000.123)
+	d2 := d1.Mul(big.NewFloat(500), big.NewFloat(0.12))
+
+	b.ReportAllocs()
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		d1.Add(d1, d2)
+	}
+}
+
+func Benchmark_decimal_Decimal_Add_same_precision(b *testing.B) {
+	d1 := NewFromFloat(1000.123)
+	d2 := NewFromFloat(500.123)
+
+	b.ReportAllocs()
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		d1.Add(d2)
+	}
+}
+
+func Benchmark_decimal_Decimal_Sub_same_precision(b *testing.B) {
+	d1 := NewFromFloat(1000.123)
+	d2 := NewFromFloat(500.123)
+
+	b.ReportAllocs()
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		d1.Add(d2)
+	}
+}
+
+func Benchmark_math_big_Float_Add_same_precision(b *testing.B) {
+	d1 := big.NewFloat(1000.123)
+	d2 := big.NewFloat(500.123)
+
+	b.ReportAllocs()
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		d1.Add(d1, d2)
+	}
+}
+
+func Benchmark_math_big_Float_Sub_same_precision(b *testing.B) {
+	d1 := big.NewFloat(1000.123)
+	d2 := big.NewFloat(500.123)
+
+	b.ReportAllocs()
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		d1.Sub(d1, d2)
+	}
+}


### PR DESCRIPTION
linked issue: https://github.com/shopspring/decimal/issues/81

before change:
```
goos: darwin
goarch: amd64
pkg: github.com/ngalayko/decimal
Benchmark_decimal_Decimal_Add_different_precision-4      2000000               822 ns/op             511 B/op         12 allocs/op
Benchmark_decimal_Decimal_Sub_different_precision-4      2000000               865 ns/op             496 B/op         12 allocs/op
Benchmark_math_big_Float_Sub_different_precision-4      100000000               10.9 ns/op             0 B/op          0 allocs/op
Benchmark_math_big_Float_Add_different_precision-4      20000000                79.7 ns/op             2 B/op          0 allocs/op
Benchmark_decimal_Decimal_Add_same_precision-4           2000000               642 ns/op             430 B/op         10 allocs/op
Benchmark_decimal_Decimal_Sub_same_precision-4           2000000               659 ns/op             427 B/op         10 allocs/op
Benchmark_math_big_Float_Add_same_precision-4           10000000               172 ns/op              48 B/op          1 allocs/op
Benchmark_math_big_Float_Sub_same_precision-4           10000000               179 ns/op              48 B/op          1 allocs/op
```

after change:
```
goos: darwin
goarch: amd64
pkg: github.com/ngalayko/decimal
Benchmark_decimal_Decimal_Add_different_precision-4      2000000               843 ns/op             511 B/op         12 allocs/op
Benchmark_decimal_Decimal_Sub_different_precision-4      2000000               999 ns/op             496 B/op         12 allocs/op
Benchmark_math_big_Float_Sub_different_precision-4      200000000                7.91 ns/op            0 B/op          0 allocs/op
Benchmark_math_big_Float_Add_different_precision-4      20000000                81.9 ns/op             0 B/op          0 allocs/op
Benchmark_decimal_Decimal_Add_same_precision-4          10000000               131 ns/op              80 B/op          2 allocs/op
Benchmark_decimal_Decimal_Sub_same_precision-4          10000000               137 ns/op              85 B/op          2 allocs/op
Benchmark_math_big_Float_Add_same_precision-4           10000000               177 ns/op              48 B/op          1 allocs/op
Benchmark_math_big_Float_Sub_same_precision-4           10000000               184 ns/op              48 B/op          1 allocs/op
```