### PR TITLE
patch function Scan to support int,int8,int16,int32  (#1)

### DIFF
--- a/decimal.go
+++ b/decimal.go
@@ -982,6 +982,26 @@ func (d *Decimal) Scan(value interface{}) error {
 		*d = NewFromFloat(v)
 		return nil
 
+	case int:
+		// also better to implement to support all type of int.
+		// profitable to create another abstract layer for testing
+		// data access with no depends on real RDBMS.
+
+		*d = New(int64(v), 0)
+		return nil
+
+	case int8:
+		*d = New(int64(v), 0)
+		return nil
+
+	case int16:
+		*d = New(int64(v), 0)
+		return nil
+
+	case int32:
+		*d = New(int64(v), 0)
+		return nil
+
 	case int64:
 		// at least in sqlite3 when the value is 0 in db, the data is sent
 		// to us as an int64 instead of a float64 ...

--- a/decimal_test.go
+++ b/decimal_test.go
@@ -1952,6 +1952,66 @@ func TestDecimal_Scan(t *testing.T) {
 	if err == nil {
 		t.Errorf("a.Scan(Foo{}) should have thrown an error but did not")
 	}
+
+	dbvalueInt8 := int8(32)
+	expected = New(int64(32), 0)
+
+	err = a.Scan(dbvalueInt8)
+	if err != nil {
+		// Scan failed... no need to test result value
+		t.Errorf("a.Scan(32) failed with message: %s", err)
+
+	} else {
+		// Scan succeeded... test resulting values
+		if !a.Equal(expected) {
+			t.Errorf("%s does not equal to %s", a, expected)
+		}
+	}
+
+	dbvalueInt16 := int16(21)
+	expected = New(int64(21), 0)
+
+	err = a.Scan(dbvalueInt16)
+	if err != nil {
+		// Scan failed... no need to test result value
+		t.Errorf("a.Scan(21) failed with message: %s", err)
+
+	} else {
+		// Scan succeeded... test resulting values
+		if !a.Equal(expected) {
+			t.Errorf("%s does not equal to %s", a, expected)
+		}
+	}
+
+	dbvalueInt32 := int32(32)
+	expected = New(int64(32), 0)
+
+	err = a.Scan(dbvalueInt32)
+	if err != nil {
+		// Scan failed... no need to test result value
+		t.Errorf("a.Scan(32) failed with message: %s", err)
+
+	} else {
+		// Scan succeeded... test resulting values
+		if !a.Equal(expected) {
+			t.Errorf("%s does not equal to %s", a, expected)
+		}
+	}
+
+	dbvalueIntNatural := 3264
+	expected = New(int64(3264), 0)
+
+	err = a.Scan(dbvalueIntNatural)
+	if err != nil {
+		// Scan failed... no need to test result value
+		t.Errorf("a.Scan(3264) failed with message: %s", err)
+
+	} else {
+		// Scan succeeded... test resulting values
+		if !a.Equal(expected) {
+			t.Errorf("%s does not equal to %s", a, expected)
+		}
+	}
 }
 
 func TestDecimal_Value(t *testing.T) {


### PR DESCRIPTION
if i have an table on RDBMS and i need to query it and map to struct looks like this
```go
type Data struct {
 A decimal.Decimal
 B decimal.Decimal
 C decimal.Decimal
}
```

and i don't want to test with actual connection to database. so i create SqlRows implementation like this
```go

// Scan ...
func (inst *MockScanner) Scan(src ...interface{}) error {
	for i, d := range src {
		switch d := d.(type) {
		case *int:
			*d = inst.data[i].(int)
		case *string:
			*d = inst.data[i].(string)
		case *float32:
			*d = inst.data[i].(float32)
		case *float64:
			*d = inst.data[i].(float64)
		default:
			if scanner, ok := d.(sql.Scanner); ok {
				if err := scanner.Scan(inst.data[i]); err != nil {
					return err
				}
			}
		}
	}

	return nil
}
```

then, i create function like this
```go
func MapData(rows *sql.SqlRows) (*Data, error) {
  var out Data
  err := rows.Scan(&out.A, &out.B, &out.C)
  return &out, err
}
```

So, I able to test this function without actual query on database like this
```go
mock := NewMockScanner(1, 2, 3) // now support int. so, it doesn't need to be NewMockScanner(int64(1), ...) or NewMockScanner(decimal.NewFromFloat(1), ...) 
out,err := MapData(mock)
So(out.A, ShouldEqual, decimal.NewFromFloat(1))
...
```

someone might think this is pointless. but, if someone have to deal with bank's project and need to write some tests for function which deal with hundred of fields (and all of them have to be mocked), this should made a point. 