### PR TITLE
Remove unnecessary decimal rescaling - memory usage optimization

### DIFF
--- a/decimal.go
+++ b/decimal.go
@@ -427,7 +427,7 @@ func (d Decimal) Abs() Decimal {
 
 // Add returns d + d2.
 func (d Decimal) Add(d2 Decimal) Decimal {
-	rd, rd2 := RescaleBoth(d, d2)
+	rd, rd2 := RescalePair(d, d2)
 
 	d3Value := new(big.Int).Add(rd.value, rd2.value)
 	return Decimal{
@@ -438,7 +438,7 @@ func (d Decimal) Add(d2 Decimal) Decimal {
 
 // Sub returns d - d2.
 func (d Decimal) Sub(d2 Decimal) Decimal {
-	rd, rd2 := RescaleBoth(d, d2)
+	rd, rd2 := RescalePair(d, d2)
 
 	d3Value := new(big.Int).Sub(rd.value, rd2.value)
 	return Decimal{
@@ -604,7 +604,7 @@ func (d Decimal) Cmp(d2 Decimal) int {
 		return d.value.Cmp(d2.value)
 	}
 
-	rd, rd2 := RescaleBoth(d, d2)
+	rd, rd2 := RescalePair(d, d2)
 
 	return rd.value.Cmp(rd2.value)
 }
@@ -1174,7 +1174,8 @@ func Avg(first Decimal, rest ...Decimal) Decimal {
 	return sum.Div(count)
 }
 
-func RescaleBoth(d1 Decimal, d2 Decimal) (Decimal, Decimal) {
+// Rescale two decimals to common exponential value (minimal exp of both decimals)
+func RescalePair(d1 Decimal, d2 Decimal) (Decimal, Decimal) {
 	d1.ensureInitialized()
 	d2.ensureInitialized()
 

--- a/decimal.go
+++ b/decimal.go
@@ -390,6 +390,14 @@ func NewFromFloatWithExponent(value float64, exp int32) Decimal {
 //
 func (d Decimal) rescale(exp int32) Decimal {
 	d.ensureInitialized()
+
+	if d.exp == exp {
+		return Decimal{
+			new(big.Int).Set(d.value),
+			d.exp,
+		}
+	}
+
 	// NOTE(vadim): must convert exps to float64 before - to prevent overflow
 	diff := math.Abs(float64(exp) - float64(d.exp))
 	value := new(big.Int).Set(d.value)
@@ -419,27 +427,23 @@ func (d Decimal) Abs() Decimal {
 
 // Add returns d + d2.
 func (d Decimal) Add(d2 Decimal) Decimal {
-	baseScale := min(d.exp, d2.exp)
-	rd := d.rescale(baseScale)
-	rd2 := d2.rescale(baseScale)
+	rd, rd2 := RescaleBoth(d, d2)
 
 	d3Value := new(big.Int).Add(rd.value, rd2.value)
 	return Decimal{
 		value: d3Value,
-		exp:   baseScale,
+		exp:   rd.exp,
 	}
 }
 
 // Sub returns d - d2.
 func (d Decimal) Sub(d2 Decimal) Decimal {
-	baseScale := min(d.exp, d2.exp)
-	rd := d.rescale(baseScale)
-	rd2 := d2.rescale(baseScale)
+	rd, rd2 := RescaleBoth(d, d2)
 
 	d3Value := new(big.Int).Sub(rd.value, rd2.value)
 	return Decimal{
 		value: d3Value,
-		exp:   baseScale,
+		exp:   rd.exp,
 	}
 }
 
@@ -600,9 +604,7 @@ func (d Decimal) Cmp(d2 Decimal) int {
 		return d.value.Cmp(d2.value)
 	}
 
-	baseExp := min(d.exp, d2.exp)
-	rd := d.rescale(baseExp)
-	rd2 := d2.rescale(baseExp)
+	rd, rd2 := RescaleBoth(d, d2)
 
 	return rd.value.Cmp(rd2.value)
 }
@@ -1172,6 +1174,21 @@ func Avg(first Decimal, rest ...Decimal) Decimal {
 	return sum.Div(count)
 }
 
+func RescaleBoth(d1 Decimal, d2 Decimal) (Decimal, Decimal) {
+	d1.ensureInitialized()
+	d2.ensureInitialized()
+
+	if d1.exp == d2.exp {
+		return d1, d2
+	}
+
+	baseScale := min(d1.exp, d2.exp)
+	if baseScale != d1.exp {
+		return d1.rescale(baseScale), d2
+	}
+	return d1, d2.rescale(baseScale)
+}
+
 func min(x, y int32) int32 {
 	if x >= y {
 		return y
@@ -1291,174 +1308,174 @@ func (d Decimal) satan() Decimal {
 }
 
 // sin coefficients
-  var _sin = [...]Decimal{
-  	NewFromFloat(1.58962301576546568060E-10), // 0x3de5d8fd1fd19ccd
-  	NewFromFloat(-2.50507477628578072866E-8), // 0xbe5ae5e5a9291f5d
-  	NewFromFloat(2.75573136213857245213E-6),  // 0x3ec71de3567d48a1
-  	NewFromFloat(-1.98412698295895385996E-4), // 0xbf2a01a019bfdf03
-  	NewFromFloat(8.33333333332211858878E-3),  // 0x3f8111111110f7d0
-  	NewFromFloat(-1.66666666666666307295E-1), // 0xbfc5555555555548
-  }
+var _sin = [...]Decimal{
+	NewFromFloat(1.58962301576546568060e-10), // 0x3de5d8fd1fd19ccd
+	NewFromFloat(-2.50507477628578072866e-8), // 0xbe5ae5e5a9291f5d
+	NewFromFloat(2.75573136213857245213e-6),  // 0x3ec71de3567d48a1
+	NewFromFloat(-1.98412698295895385996e-4), // 0xbf2a01a019bfdf03
+	NewFromFloat(8.33333333332211858878e-3),  // 0x3f8111111110f7d0
+	NewFromFloat(-1.66666666666666307295e-1), // 0xbfc5555555555548
+}
 
 // Sin returns the sine of the radian argument x.
-  func (d Decimal) Sin() Decimal {
-		PI4A := NewFromFloat(7.85398125648498535156E-1)                             // 0x3fe921fb40000000, Pi/4 split into three parts
-		PI4B := NewFromFloat(3.77489470793079817668E-8)                             // 0x3e64442d00000000,
-		PI4C := NewFromFloat(2.69515142907905952645E-15)                            // 0x3ce8469898cc5170,
-		M4PI := NewFromFloat(1.273239544735162542821171882678754627704620361328125) // 4/pi
+func (d Decimal) Sin() Decimal {
+	PI4A := NewFromFloat(7.85398125648498535156e-1)                             // 0x3fe921fb40000000, Pi/4 split into three parts
+	PI4B := NewFromFloat(3.77489470793079817668e-8)                             // 0x3e64442d00000000,
+	PI4C := NewFromFloat(2.69515142907905952645e-15)                            // 0x3ce8469898cc5170,
+	M4PI := NewFromFloat(1.273239544735162542821171882678754627704620361328125) // 4/pi
 
-  	if d.Equal(NewFromFloat(0.0)) {
-			return d
-		}
-  	// make argument positive but save the sign
-  	sign := false
-  	if d.LessThan(NewFromFloat(0.0)) {
-  		d = d.Neg()
-  		sign = true
-  	}
+	if d.Equal(NewFromFloat(0.0)) {
+		return d
+	}
+	// make argument positive but save the sign
+	sign := false
+	if d.LessThan(NewFromFloat(0.0)) {
+		d = d.Neg()
+		sign = true
+	}
 
-		j := d.Mul(M4PI).IntPart()    // integer part of x/(Pi/4), as integer for tests on the phase angle
-  	y := NewFromFloat(float64(j)) // integer part of x/(Pi/4), as float
+	j := d.Mul(M4PI).IntPart()    // integer part of x/(Pi/4), as integer for tests on the phase angle
+	y := NewFromFloat(float64(j)) // integer part of x/(Pi/4), as float
 
-  	// map zeros to origin
-  	if j&1 == 1 {
-  		j++
-  		y = y.Add(NewFromFloat(1.0))
-  	}
-  	j &= 7 // octant modulo 2Pi radians (360 degrees)
-  	// reflect in x axis
-  	if j > 3 {
-  		sign = !sign
-  		j -= 4
-  	}
-		z := d.Sub(y.Mul(PI4A)).Sub(y.Mul(PI4B)).Sub(y.Mul(PI4C)) // Extended precision modular arithmetic
-  	zz := z.Mul(z)
+	// map zeros to origin
+	if j&1 == 1 {
+		j++
+		y = y.Add(NewFromFloat(1.0))
+	}
+	j &= 7 // octant modulo 2Pi radians (360 degrees)
+	// reflect in x axis
+	if j > 3 {
+		sign = !sign
+		j -= 4
+	}
+	z := d.Sub(y.Mul(PI4A)).Sub(y.Mul(PI4B)).Sub(y.Mul(PI4C)) // Extended precision modular arithmetic
+	zz := z.Mul(z)
 
-  	if j == 1 || j == 2 {
-			w := zz.Mul(zz).Mul(_cos[0].Mul(zz).Add(_cos[1]).Mul(zz).Add(_cos[2]).Mul(zz).Add(_cos[3]).Mul(zz).Add(_cos[4]).Mul(zz).Add(_cos[5]))
-			y = NewFromFloat(1.0).Sub(NewFromFloat(0.5).Mul(zz)).Add(w)
-  	} else {
-			y = z.Add(z.Mul(zz).Mul(_sin[0].Mul(zz).Add(_sin[1]).Mul(zz).Add(_sin[2]).Mul(zz).Add(_sin[3]).Mul(zz).Add(_sin[4]).Mul(zz).Add(_sin[5])))
-  	}
-  	if sign {
-  		y = y.Neg()
-  	}
-  	return y
-  }
+	if j == 1 || j == 2 {
+		w := zz.Mul(zz).Mul(_cos[0].Mul(zz).Add(_cos[1]).Mul(zz).Add(_cos[2]).Mul(zz).Add(_cos[3]).Mul(zz).Add(_cos[4]).Mul(zz).Add(_cos[5]))
+		y = NewFromFloat(1.0).Sub(NewFromFloat(0.5).Mul(zz)).Add(w)
+	} else {
+		y = z.Add(z.Mul(zz).Mul(_sin[0].Mul(zz).Add(_sin[1]).Mul(zz).Add(_sin[2]).Mul(zz).Add(_sin[3]).Mul(zz).Add(_sin[4]).Mul(zz).Add(_sin[5])))
+	}
+	if sign {
+		y = y.Neg()
+	}
+	return y
+}
 
-	// cos coefficients
-  var _cos = [...]Decimal{
-  	NewFromFloat(-1.13585365213876817300E-11), // 0xbda8fa49a0861a9b
-  	NewFromFloat(2.08757008419747316778E-9),   // 0x3e21ee9d7b4e3f05
-  	NewFromFloat(-2.75573141792967388112E-7),  // 0xbe927e4f7eac4bc6
-  	NewFromFloat(2.48015872888517045348E-5),   // 0x3efa01a019c844f5
-  	NewFromFloat(-1.38888888888730564116E-3),  // 0xbf56c16c16c14f91
-  	NewFromFloat(4.16666666666665929218E-2),   // 0x3fa555555555554b
-  }
+// cos coefficients
+var _cos = [...]Decimal{
+	NewFromFloat(-1.13585365213876817300e-11), // 0xbda8fa49a0861a9b
+	NewFromFloat(2.08757008419747316778e-9),   // 0x3e21ee9d7b4e3f05
+	NewFromFloat(-2.75573141792967388112e-7),  // 0xbe927e4f7eac4bc6
+	NewFromFloat(2.48015872888517045348e-5),   // 0x3efa01a019c844f5
+	NewFromFloat(-1.38888888888730564116e-3),  // 0xbf56c16c16c14f91
+	NewFromFloat(4.16666666666665929218e-2),   // 0x3fa555555555554b
+}
 
-	// Cos returns the cosine of the radian argument x.
-  func (d Decimal) Cos() Decimal {
+// Cos returns the cosine of the radian argument x.
+func (d Decimal) Cos() Decimal {
 
-		PI4A := NewFromFloat(7.85398125648498535156E-1)                             // 0x3fe921fb40000000, Pi/4 split into three parts
-		PI4B := NewFromFloat(3.77489470793079817668E-8)                             // 0x3e64442d00000000,
-		PI4C := NewFromFloat(2.69515142907905952645E-15)                            // 0x3ce8469898cc5170,
-		M4PI := NewFromFloat(1.273239544735162542821171882678754627704620361328125) // 4/pi
+	PI4A := NewFromFloat(7.85398125648498535156e-1)                             // 0x3fe921fb40000000, Pi/4 split into three parts
+	PI4B := NewFromFloat(3.77489470793079817668e-8)                             // 0x3e64442d00000000,
+	PI4C := NewFromFloat(2.69515142907905952645e-15)                            // 0x3ce8469898cc5170,
+	M4PI := NewFromFloat(1.273239544735162542821171882678754627704620361328125) // 4/pi
 
-  	// make argument positive
-		sign := false
-  	if d.LessThan(NewFromFloat(0.0)) {
-  		d = d.Neg()
-  	}
+	// make argument positive
+	sign := false
+	if d.LessThan(NewFromFloat(0.0)) {
+		d = d.Neg()
+	}
 
-		j := d.Mul(M4PI).IntPart()    // integer part of x/(Pi/4), as integer for tests on the phase angle
-  	y := NewFromFloat(float64(j)) // integer part of x/(Pi/4), as float
+	j := d.Mul(M4PI).IntPart()    // integer part of x/(Pi/4), as integer for tests on the phase angle
+	y := NewFromFloat(float64(j)) // integer part of x/(Pi/4), as float
 
-  	// map zeros to origin
-  	if j&1 == 1 {
-  		j++
-  		y = y.Add(NewFromFloat(1.0))
-  	}
-  	j &= 7 // octant modulo 2Pi radians (360 degrees)
-  	// reflect in x axis
-  	if j > 3 {
-  		sign = !sign
-  		j -= 4
-  	}
-		if j > 1 {
-  		sign = !sign
-  	}
+	// map zeros to origin
+	if j&1 == 1 {
+		j++
+		y = y.Add(NewFromFloat(1.0))
+	}
+	j &= 7 // octant modulo 2Pi radians (360 degrees)
+	// reflect in x axis
+	if j > 3 {
+		sign = !sign
+		j -= 4
+	}
+	if j > 1 {
+		sign = !sign
+	}
 
-		z := d.Sub(y.Mul(PI4A)).Sub(y.Mul(PI4B)).Sub(y.Mul(PI4C)) // Extended precision modular arithmetic
-  	zz := z.Mul(z)
+	z := d.Sub(y.Mul(PI4A)).Sub(y.Mul(PI4B)).Sub(y.Mul(PI4C)) // Extended precision modular arithmetic
+	zz := z.Mul(z)
 
-  	if j == 1 || j == 2 {
-			y = z.Add(z.Mul(zz).Mul(_sin[0].Mul(zz).Add(_sin[1]).Mul(zz).Add(_sin[2]).Mul(zz).Add(_sin[3]).Mul(zz).Add(_sin[4]).Mul(zz).Add(_sin[5])))
-  	} else {
-			w := zz.Mul(zz).Mul(_cos[0].Mul(zz).Add(_cos[1]).Mul(zz).Add(_cos[2]).Mul(zz).Add(_cos[3]).Mul(zz).Add(_cos[4]).Mul(zz).Add(_cos[5]))
-			y = NewFromFloat(1.0).Sub(NewFromFloat(0.5).Mul(zz)).Add(w)
-  	}
-  	if sign {
-  		y = y.Neg()
-  	}
-  	return y
-  }
+	if j == 1 || j == 2 {
+		y = z.Add(z.Mul(zz).Mul(_sin[0].Mul(zz).Add(_sin[1]).Mul(zz).Add(_sin[2]).Mul(zz).Add(_sin[3]).Mul(zz).Add(_sin[4]).Mul(zz).Add(_sin[5])))
+	} else {
+		w := zz.Mul(zz).Mul(_cos[0].Mul(zz).Add(_cos[1]).Mul(zz).Add(_cos[2]).Mul(zz).Add(_cos[3]).Mul(zz).Add(_cos[4]).Mul(zz).Add(_cos[5]))
+		y = NewFromFloat(1.0).Sub(NewFromFloat(0.5).Mul(zz)).Add(w)
+	}
+	if sign {
+		y = y.Neg()
+	}
+	return y
+}
 
-	var _tanP = [...]Decimal{
-  	NewFromFloat(-1.30936939181383777646E+4), // 0xc0c992d8d24f3f38
-  	NewFromFloat(1.15351664838587416140E+6),  // 0x413199eca5fc9ddd
-  	NewFromFloat(-1.79565251976484877988E+7), // 0xc1711fead3299176
-  }
-  var _tanQ = [...]Decimal{
-  	NewFromFloat(1.00000000000000000000E+0),
-  	NewFromFloat(1.36812963470692954678E+4),  //0x40cab8a5eeb36572
-  	NewFromFloat(-1.32089234440210967447E+6), //0xc13427bc582abc96
-  	NewFromFloat(2.50083801823357915839E+7),  //0x4177d98fc2ead8ef
-  	NewFromFloat(-5.38695755929454629881E+7), //0xc189afe03cbe5a31
-  }
+var _tanP = [...]Decimal{
+	NewFromFloat(-1.30936939181383777646e+4), // 0xc0c992d8d24f3f38
+	NewFromFloat(1.15351664838587416140e+6),  // 0x413199eca5fc9ddd
+	NewFromFloat(-1.79565251976484877988e+7), // 0xc1711fead3299176
+}
+var _tanQ = [...]Decimal{
+	NewFromFloat(1.00000000000000000000e+0),
+	NewFromFloat(1.36812963470692954678e+4),  //0x40cab8a5eeb36572
+	NewFromFloat(-1.32089234440210967447e+6), //0xc13427bc582abc96
+	NewFromFloat(2.50083801823357915839e+7),  //0x4177d98fc2ead8ef
+	NewFromFloat(-5.38695755929454629881e+7), //0xc189afe03cbe5a31
+}
 
-  // Tan returns the tangent of the radian argument x.
-  func (d Decimal) Tan() Decimal {
+// Tan returns the tangent of the radian argument x.
+func (d Decimal) Tan() Decimal {
 
-		PI4A := NewFromFloat(7.85398125648498535156E-1)                             // 0x3fe921fb40000000, Pi/4 split into three parts
-		PI4B := NewFromFloat(3.77489470793079817668E-8)                             // 0x3e64442d00000000,
-		PI4C := NewFromFloat(2.69515142907905952645E-15)                            // 0x3ce8469898cc5170,
-		M4PI := NewFromFloat(1.273239544735162542821171882678754627704620361328125) // 4/pi
+	PI4A := NewFromFloat(7.85398125648498535156e-1)                             // 0x3fe921fb40000000, Pi/4 split into three parts
+	PI4B := NewFromFloat(3.77489470793079817668e-8)                             // 0x3e64442d00000000,
+	PI4C := NewFromFloat(2.69515142907905952645e-15)                            // 0x3ce8469898cc5170,
+	M4PI := NewFromFloat(1.273239544735162542821171882678754627704620361328125) // 4/pi
 
-		if d.Equal(NewFromFloat(0.0)) {
-			return d
-		}
+	if d.Equal(NewFromFloat(0.0)) {
+		return d
+	}
 
-  	// make argument positive but save the sign
-  	sign := false
-  	if d.LessThan(NewFromFloat(0.0)) {
-  		d = d.Neg()
-  		sign = true
-  	}
+	// make argument positive but save the sign
+	sign := false
+	if d.LessThan(NewFromFloat(0.0)) {
+		d = d.Neg()
+		sign = true
+	}
 
-		j := d.Mul(M4PI).IntPart()    // integer part of x/(Pi/4), as integer for tests on the phase angle
-  	y := NewFromFloat(float64(j)) // integer part of x/(Pi/4), as float
+	j := d.Mul(M4PI).IntPart()    // integer part of x/(Pi/4), as integer for tests on the phase angle
+	y := NewFromFloat(float64(j)) // integer part of x/(Pi/4), as float
 
-  	// map zeros to origin
-  	if j&1 == 1 {
-  		j++
-  		y = y.Add(NewFromFloat(1.0))
-  	}
+	// map zeros to origin
+	if j&1 == 1 {
+		j++
+		y = y.Add(NewFromFloat(1.0))
+	}
 
-		z := d.Sub(y.Mul(PI4A)).Sub(y.Mul(PI4B)).Sub(y.Mul(PI4C)) // Extended precision modular arithmetic
-  	zz := z.Mul(z)
+	z := d.Sub(y.Mul(PI4A)).Sub(y.Mul(PI4B)).Sub(y.Mul(PI4C)) // Extended precision modular arithmetic
+	zz := z.Mul(z)
 
-  	if zz.GreaterThan(NewFromFloat(1e-14)) {
-			w := zz.Mul(_tanP[0].Mul(zz).Add(_tanP[1]).Mul(zz).Add(_tanP[2]))
-			x := zz.Add(_tanQ[1]).Mul(zz).Add(_tanQ[2]).Mul(zz).Add(_tanQ[3]).Mul(zz).Add(_tanQ[4])
-			y = z.Add(z.Mul(w.Div(x)))
-  	} else {
-  		y = z
-  	}
-  	if j&2 == 2 {
-			y = NewFromFloat(-1.0).Div(y)
-  	}
-  	if sign {
-  		y = y.Neg()
-  	}
-  	return y
-  }
+	if zz.GreaterThan(NewFromFloat(1e-14)) {
+		w := zz.Mul(_tanP[0].Mul(zz).Add(_tanP[1]).Mul(zz).Add(_tanP[2]))
+		x := zz.Add(_tanQ[1]).Mul(zz).Add(_tanQ[2]).Mul(zz).Add(_tanQ[3]).Mul(zz).Add(_tanQ[4])
+		y = z.Add(z.Mul(w.Div(x)))
+	} else {
+		y = z
+	}
+	if j&2 == 2 {
+		y = NewFromFloat(-1.0).Div(y)
+	}
+	if sign {
+		y = y.Neg()
+	}
+	return y
+}

--- a/decimal_bench_test.go
+++ b/decimal_bench_test.go
@@ -1,0 +1,230 @@
+package decimal
+
+import (
+	"math"
+	"math/big"
+	"math/rand"
+	"sort"
+	"strconv"
+	"testing"
+)
+
+type DecimalSlice []Decimal
+
+func (p DecimalSlice) Len() int           { return len(p) }
+func (p DecimalSlice) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
+func (p DecimalSlice) Less(i, j int) bool { return p[i].Cmp(p[j]) < 0 }
+
+func BenchmarkNewFromFloatWithExponent(b *testing.B) {
+	rng := rand.New(rand.NewSource(0xdead1337))
+	in := make([]float64, b.N)
+	for i := range in {
+		in[i] = rng.NormFloat64() * 10e20
+	}
+	b.ReportAllocs()
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		in := rng.NormFloat64() * 10e20
+		_ = NewFromFloatWithExponent(in, math.MinInt32)
+	}
+}
+
+func BenchmarkNewFromFloat(b *testing.B) {
+	rng := rand.New(rand.NewSource(0xdead1337))
+	in := make([]float64, b.N)
+	for i := range in {
+		in[i] = rng.NormFloat64() * 10e20
+	}
+	b.ReportAllocs()
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		_ = NewFromFloat(in[i])
+	}
+}
+
+func BenchmarkNewFromStringFloat(b *testing.B) {
+	rng := rand.New(rand.NewSource(0xdead1337))
+	in := make([]float64, b.N)
+	for i := range in {
+		in[i] = rng.NormFloat64() * 10e20
+	}
+	b.ReportAllocs()
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		in := strconv.FormatFloat(in[i], 'f', -1, 64)
+		_, _ = NewFromString(in)
+	}
+}
+
+func Benchmark_FloorFast(b *testing.B) {
+	input := New(200, 2)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		input.Floor()
+	}
+}
+
+func Benchmark_FloorRegular(b *testing.B) {
+	input := New(200, -2)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		input.Floor()
+	}
+}
+
+func Benchmark_DivideOriginal(b *testing.B) {
+	tcs := createDivTestCases()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for _, tc := range tcs {
+			d := tc.d
+			if sign(tc.d2) == 0 {
+				continue
+			}
+			d2 := tc.d2
+			prec := tc.prec
+			a := d.DivOld(d2, int(prec))
+			if sign(a) > 2 {
+				panic("dummy panic")
+			}
+		}
+	}
+}
+
+func Benchmark_DivideNew(b *testing.B) {
+	tcs := createDivTestCases()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for _, tc := range tcs {
+			d := tc.d
+			if sign(tc.d2) == 0 {
+				continue
+			}
+			d2 := tc.d2
+			prec := tc.prec
+			a := d.DivRound(d2, prec)
+			if sign(a) > 2 {
+				panic("dummy panic")
+			}
+		}
+	}
+}
+
+func BenchmarkDecimal_RoundCash_Five(b *testing.B) {
+	const want = "3.50"
+	for i := 0; i < b.N; i++ {
+		val := New(3478, -3)
+		if have := val.StringFixedCash(5); have != want {
+			b.Fatalf("\nHave: %q\nWant: %q", have, want)
+		}
+	}
+}
+
+func BenchmarkDecimal_RoundCash_Fifteen(b *testing.B) {
+	const want = "6.30"
+	for i := 0; i < b.N; i++ {
+		val := New(635, -2)
+		if have := val.StringFixedCash(15); have != want {
+			b.Fatalf("\nHave: %q\nWant: %q", have, want)
+		}
+	}
+}
+
+func Benchmark_Cmp(b *testing.B) {
+	decimals := DecimalSlice([]Decimal{})
+	for i := 0; i < 1000000; i++ {
+		decimals = append(decimals, New(int64(i), 0))
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		sort.Sort(decimals)
+	}
+}
+
+func Benchmark_decimal_Decimal_Add_different_precision(b *testing.B) {
+	d1 := NewFromFloat(1000.123)
+	d2 := NewFromFloat(500).Mul(NewFromFloat(0.12))
+
+	b.ReportAllocs()
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		d1.Add(d2)
+	}
+}
+
+func Benchmark_decimal_Decimal_Sub_different_precision(b *testing.B) {
+	d1 := NewFromFloat(1000.123)
+	d2 := NewFromFloat(500).Mul(NewFromFloat(0.12))
+
+	b.ReportAllocs()
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		d1.Sub(d2)
+	}
+}
+
+func Benchmark_math_big_Float_Sub_different_precision(b *testing.B) {
+	d1 := big.NewFloat(1000.123)
+	d2 := d1.Mul(big.NewFloat(500), big.NewFloat(0.12))
+
+	b.ReportAllocs()
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		d1.Sub(d1, d2)
+	}
+}
+
+func Benchmark_math_big_Float_Add_different_precision(b *testing.B) {
+	d1 := big.NewFloat(1000.123)
+	d2 := d1.Mul(big.NewFloat(500), big.NewFloat(0.12))
+
+	b.ReportAllocs()
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		d1.Add(d1, d2)
+	}
+}
+
+func Benchmark_decimal_Decimal_Add_same_precision(b *testing.B) {
+	d1 := NewFromFloat(1000.123)
+	d2 := NewFromFloat(500.123)
+
+	b.ReportAllocs()
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		d1.Add(d2)
+	}
+}
+
+func Benchmark_decimal_Decimal_Sub_same_precision(b *testing.B) {
+	d1 := NewFromFloat(1000.123)
+	d2 := NewFromFloat(500.123)
+
+	b.ReportAllocs()
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		d1.Add(d2)
+	}
+}
+
+func Benchmark_math_big_Float_Add_same_precision(b *testing.B) {
+	d1 := big.NewFloat(1000.123)
+	d2 := big.NewFloat(500.123)
+
+	b.ReportAllocs()
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		d1.Add(d1, d2)
+	}
+}
+
+func Benchmark_math_big_Float_Sub_same_precision(b *testing.B) {
+	d1 := big.NewFloat(1000.123)
+	d2 := big.NewFloat(500.123)
+
+	b.ReportAllocs()
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		d1.Sub(d1, d2)
+	}
+}

--- a/decimal_bench_test.go
+++ b/decimal_bench_test.go
@@ -2,7 +2,6 @@ package decimal
 
 import (
 	"math"
-	"math/big"
 	"math/rand"
 	"sort"
 	"strconv"
@@ -163,28 +162,6 @@ func Benchmark_decimal_Decimal_Sub_different_precision(b *testing.B) {
 	}
 }
 
-func Benchmark_math_big_Float_Sub_different_precision(b *testing.B) {
-	d1 := big.NewFloat(1000.123)
-	d2 := d1.Mul(big.NewFloat(500), big.NewFloat(0.12))
-
-	b.ReportAllocs()
-	b.StartTimer()
-	for i := 0; i < b.N; i++ {
-		d1.Sub(d1, d2)
-	}
-}
-
-func Benchmark_math_big_Float_Add_different_precision(b *testing.B) {
-	d1 := big.NewFloat(1000.123)
-	d2 := d1.Mul(big.NewFloat(500), big.NewFloat(0.12))
-
-	b.ReportAllocs()
-	b.StartTimer()
-	for i := 0; i < b.N; i++ {
-		d1.Add(d1, d2)
-	}
-}
-
 func Benchmark_decimal_Decimal_Add_same_precision(b *testing.B) {
 	d1 := NewFromFloat(1000.123)
 	d2 := NewFromFloat(500.123)
@@ -204,27 +181,5 @@ func Benchmark_decimal_Decimal_Sub_same_precision(b *testing.B) {
 	b.StartTimer()
 	for i := 0; i < b.N; i++ {
 		d1.Add(d2)
-	}
-}
-
-func Benchmark_math_big_Float_Add_same_precision(b *testing.B) {
-	d1 := big.NewFloat(1000.123)
-	d2 := big.NewFloat(500.123)
-
-	b.ReportAllocs()
-	b.StartTimer()
-	for i := 0; i < b.N; i++ {
-		d1.Add(d1, d2)
-	}
-}
-
-func Benchmark_math_big_Float_Sub_same_precision(b *testing.B) {
-	d1 := big.NewFloat(1000.123)
-	d2 := big.NewFloat(500.123)
-
-	b.ReportAllocs()
-	b.StartTimer()
-	for i := 0; i < b.N; i++ {
-		d1.Sub(d1, d2)
 	}
 }

--- a/decimal_test.go
+++ b/decimal_test.go
@@ -9,7 +9,6 @@ import (
 	"math/big"
 	"math/rand"
 	"reflect"
-	"sort"
 	"strconv"
 	"strings"
 	"testing"
@@ -198,47 +197,6 @@ func TestNewFromFloat32Quick(t *testing.T) {
 	}, &quick.Config{})
 	if err != nil {
 		t.Error(err)
-	}
-}
-
-func BenchmarkNewFromFloatWithExponent(b *testing.B) {
-	rng := rand.New(rand.NewSource(0xdead1337))
-	in := make([]float64, b.N)
-	for i := range in {
-		in[i] = rng.NormFloat64() * 10e20
-	}
-	b.ReportAllocs()
-	b.StartTimer()
-	for i := 0; i < b.N; i++ {
-		in := rng.NormFloat64() * 10e20
-		_ = NewFromFloatWithExponent(in, math.MinInt32)
-	}
-}
-
-func BenchmarkNewFromFloat(b *testing.B) {
-	rng := rand.New(rand.NewSource(0xdead1337))
-	in := make([]float64, b.N)
-	for i := range in {
-		in[i] = rng.NormFloat64() * 10e20
-	}
-	b.ReportAllocs()
-	b.StartTimer()
-	for i := 0; i < b.N; i++ {
-		_ = NewFromFloat(in[i])
-	}
-}
-
-func BenchmarkNewFromStringFloat(b *testing.B) {
-	rng := rand.New(rand.NewSource(0xdead1337))
-	in := make([]float64, b.N)
-	for i := range in {
-		in[i] = rng.NormFloat64() * 10e20
-	}
-	b.ReportAllocs()
-	b.StartTimer()
-	for i := 0; i < b.N; i++ {
-		in := strconv.FormatFloat(in[i], 'f', -1, 64)
-		_, _ = NewFromString(in)
 	}
 }
 
@@ -859,22 +817,6 @@ func TestDecimal_Floor(t *testing.T) {
 	for _, test := range testsWithDecimals {
 		expected, _ := NewFromString(test.expected)
 		assertFloor(test.input, expected)
-	}
-}
-
-func Benchmark_FloorFast(b *testing.B) {
-	input := New(200, 2)
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		input.Floor()
-	}
-}
-
-func Benchmark_FloorRegular(b *testing.B) {
-	input := New(200, -2)
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		input.Floor()
 	}
 }
 
@@ -1525,44 +1467,6 @@ func (d Decimal) DivOld(d2 Decimal, prec int) Decimal {
 	return ret
 }
 
-func Benchmark_DivideOriginal(b *testing.B) {
-	tcs := createDivTestCases()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		for _, tc := range tcs {
-			d := tc.d
-			if sign(tc.d2) == 0 {
-				continue
-			}
-			d2 := tc.d2
-			prec := tc.prec
-			a := d.DivOld(d2, int(prec))
-			if sign(a) > 2 {
-				panic("dummy panic")
-			}
-		}
-	}
-}
-
-func Benchmark_DivideNew(b *testing.B) {
-	tcs := createDivTestCases()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		for _, tc := range tcs {
-			d := tc.d
-			if sign(tc.d2) == 0 {
-				continue
-			}
-			d2 := tc.d2
-			prec := tc.prec
-			a := d.DivRound(d2, prec)
-			if sign(a) > 2 {
-				panic("dummy panic")
-			}
-		}
-	}
-}
-
 func sign(d Decimal) int {
 	return d.value.Sign()
 }
@@ -1717,26 +1621,6 @@ func TestDecimal_RoundCash_Panic(t *testing.T) {
 	}()
 	d, _ := NewFromString("1")
 	d.RoundCash(231)
-}
-
-func BenchmarkDecimal_RoundCash_Five(b *testing.B) {
-	const want = "3.50"
-	for i := 0; i < b.N; i++ {
-		val := New(3478, -3)
-		if have := val.StringFixedCash(5); have != want {
-			b.Fatalf("\nHave: %q\nWant: %q", have, want)
-		}
-	}
-}
-
-func BenchmarkDecimal_RoundCash_Fifteen(b *testing.B) {
-	const want = "6.30"
-	for i := 0; i < b.N; i++ {
-		val := New(635, -2)
-		if have := val.StringFixedCash(15); have != want {
-			b.Fatalf("\nHave: %q\nWant: %q", have, want)
-		}
-	}
 }
 
 func TestDecimal_Mod(t *testing.T) {
@@ -2190,22 +2074,6 @@ func TestDecimal_Coefficient(t *testing.T) {
 	co.Set(big.NewInt(0))
 	if d.IntPart() != 123 {
 		t.Error("Modifying coefficient modified Decimal; Got:", d)
-	}
-}
-
-type DecimalSlice []Decimal
-
-func (p DecimalSlice) Len() int           { return len(p) }
-func (p DecimalSlice) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
-func (p DecimalSlice) Less(i, j int) bool { return p[i].Cmp(p[j]) < 0 }
-func Benchmark_Cmp(b *testing.B) {
-	decimals := DecimalSlice([]Decimal{})
-	for i := 0; i < 1000000; i++ {
-		decimals = append(decimals, New(int64(i), 0))
-	}
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		sort.Sort(decimals)
 	}
 }
 


### PR DESCRIPTION
I've tried to fix the performance issue mentioned in #81. Partially succeed as I couldn't simply return an already existing decimal object in `rescale` method due to some problems with `DivMod` pointer receiver method that change decimal's `value` attribute. As a workaround, I've created `RescalePair` helper function that rescales only one or none decimals from pair to avoid unnecessary memory allocations.

Results of optimization shown below. 

I've used benchmarks implemented by @ngalaiko in PR #102. Thanks for the contributions to the library, I really appreciate it. 

Before:
```
Benchmark_decimal_Decimal_Add_different_precision-8      3753075               317 ns/op             605 B/op         12 allocs/op
Benchmark_decimal_Decimal_Sub_different_precision-8      3879166               308 ns/op             557 B/op         12 allocs/op
Benchmark_math_big_Float_Sub_different_precision-8      372282800                3.24 ns/op            2 B/op          0 allocs/op
Benchmark_math_big_Float_Add_different_precision-8      37566445                31.4 ns/op            26 B/op          0 allocs/op
Benchmark_decimal_Decimal_Add_same_precision-8           6109453               201 ns/op             349 B/op          8 allocs/op
Benchmark_decimal_Decimal_Sub_same_precision-8           6106828               197 ns/op             349 B/op          8 allocs/op
Benchmark_math_big_Float_Add_same_precision-8           18792164                65.3 ns/op           105 B/op          1 allocs/op
Benchmark_math_big_Float_Sub_same_precision-8           18800349                65.5 ns/op           103 B/op          1 allocs/op
```
After:
```
Benchmark_decimal_Decimal_Add_different_precision-8      4774314               253 ns/op             493 B/op          9 allocs/op
Benchmark_decimal_Decimal_Sub_different_precision-8      4920571               243 ns/op             446 B/op          9 allocs/op
Benchmark_math_big_Float_Sub_different_precision-8      458631969                2.62 ns/op            2 B/op          0 allocs/op
Benchmark_math_big_Float_Add_different_precision-8      37542704                31.3 ns/op            26 B/op          0 allocs/op
Benchmark_decimal_Decimal_Add_same_precision-8          20565834                59.5 ns/op           130 B/op          2 allocs/op
Benchmark_decimal_Decimal_Sub_same_precision-8          20362555                61.1 ns/op           131 B/op          2 allocs/op
Benchmark_math_big_Float_Add_same_precision-8           18800202                65.7 ns/op           103 B/op          1 allocs/op
Benchmark_math_big_Float_Sub_same_precision-8           18510948                65.4 ns/op           103 B/op          1 allocs/op
```