### PR TITLE
CI, test build on the three latest Go version and the oldest one available

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: go
 
 go:
-  - 1.2.2
-  - 1.13
+  - 1.2.x
+  - 1.12.x
+  - 1.13.x
   - tip
 
 install:


### PR DESCRIPTION
We should stick to the common Go open-source libraries pattern of strictly testing libs for the 3 latest Go (currently 1.12, 1.13 and 1.14) versions available. 