### PR TITLE
Drop support for Go versions older than 1.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.6.x
+  - 1.7.x
   - 1.12.x
   - 1.13.x
   - tip

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.5.x
+  - 1.6.x
   - 1.12.x
   - 1.13.x
   - tip

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.2.x
+  - 1.5.x
   - 1.12.x
   - 1.13.x
   - tip

--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ NOTE: can "only" represent numbers with a maximum of 2^31 digits after the decim
 
 Run `go get github.com/shopspring/decimal`
 
+## Requirements 
+
+Decimal library requires Go version `>=1.7`
+
 ## Usage
 
 ```go


### PR DESCRIPTION
As we want to introduce new helper methods that rely on functionalities available from Go version >1.5 we decided to drop support for old Go versions. 
We would still support as a bunch of older go version, but we have to think more strictly about moving this library forward. 