### PR TITLE
Update documentation, clean up package level documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,15 @@
 
 Arbitrary-precision fixed-point decimal numbers in go.
 
-NOTE: can "only" represent numbers with a maximum of 2^31 digits after the decimal point.
+_Note:_ Decimal library can "only" represent numbers with a maximum of 2^31 digits after the decimal point.
 
 ## Features
 
- * the zero-value is 0, and is safe to use without initialization
- * addition, subtraction, multiplication with no loss of precision
- * division with specified precision
- * database/sql serialization/deserialization
- * json and xml serialization/deserialization
+ * The zero-value is 0, and is safe to use without initialization
+ * Addition, subtraction, multiplication with no loss of precision
+ * Division with specified precision
+ * Database/sql serialization/deserialization
+ * JSON and XML serialization/deserialization
 
 ## Install
 
@@ -70,8 +70,8 @@ http://godoc.org/github.com/shopspring/decimal
 
 #### Why don't you just use float64?
 
-Because float64s (or any binary floating point type, actually) can't represent
-numbers such as 0.1 exactly.
+Because float64 (or any binary floating point type, actually) can't represent
+numbers such as `0.1` exactly.
 
 Consider this code: http://play.golang.org/p/TQBd4yJe6B You might expect that
 it prints out `10`, but it actually prints `9.999999999999831`. Over time,

--- a/decimal-go.go
+++ b/decimal-go.go
@@ -2,6 +2,13 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// Multiprecision decimal numbers.
+// For floating-point formatting only; not general purpose.
+// Only operations are assign and (binary) left/right shift.
+// Can do binary floating point in multiprecision decimal precisely
+// because 2 divides 10; cannot do decimal floating point
+// in multiprecision binary precisely.
+
 package decimal
 
 type decimal struct {

--- a/decimal-go.go
+++ b/decimal-go.go
@@ -2,12 +2,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// Multiprecision decimal numbers.
-// For floating-point formatting only; not general purpose.
-// Only operations are assign and (binary) left/right shift.
-// Can do binary floating point in multiprecision decimal precisely
-// because 2 divides 10; cannot do decimal floating point
-// in multiprecision binary precisely.
 package decimal
 
 type decimal struct {

--- a/decimal.go
+++ b/decimal.go
@@ -31,14 +31,14 @@ import (
 //
 // Example:
 //
-//     d1 := decimal.NewFromFloat(2).Div(decimal.NewFromFloat(3)
+//     d1 := decimal.NewFromFloat(2).Div(decimal.NewFromFloat(3))
 //     d1.String() // output: "0.6666666666666667"
-//     d2 := decimal.NewFromFloat(2).Div(decimal.NewFromFloat(30000)
+//     d2 := decimal.NewFromFloat(2).Div(decimal.NewFromFloat(30000))
 //     d2.String() // output: "0.0000666666666667"
-//     d3 := decimal.NewFromFloat(20000).Div(decimal.NewFromFloat(3)
+//     d3 := decimal.NewFromFloat(20000).Div(decimal.NewFromFloat(3))
 //     d3.String() // output: "6666.6666666666666667"
 //     decimal.DivisionPrecision = 3
-//     d4 := decimal.NewFromFloat(2).Div(decimal.NewFromFloat(3)
+//     d4 := decimal.NewFromFloat(2).Div(decimal.NewFromFloat(3))
 //     d4.String() // output: "0.667"
 //
 var DivisionPrecision = 16

--- a/rounding.go
+++ b/rounding.go
@@ -2,12 +2,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// Multiprecision decimal numbers.
-// For floating-point formatting only; not general purpose.
-// Only operations are assign and (binary) left/right shift.
-// Can do binary floating point in multiprecision decimal precisely
-// because 2 divides 10; cannot do decimal floating point
-// in multiprecision binary precisely.
 package decimal
 
 type floatInfo struct {

--- a/rounding.go
+++ b/rounding.go
@@ -2,6 +2,13 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// Multiprecision decimal numbers.
+// For floating-point formatting only; not general purpose.
+// Only operations are assign and (binary) left/right shift.
+// Can do binary floating point in multiprecision decimal precisely
+// because 2 divides 10; cannot do decimal floating point
+// in multiprecision binary precisely.
+
 package decimal
 
 type floatInfo struct {


### PR DESCRIPTION
Few things changes since we start maintaining this library, so let's update docs. 
This PR also should improve go report cards.

Btw. I removed package docs from `decimal-go` and `rounding` modules to improve [godoc](https://godoc.org/github.com/shopspring/decimal). Should I transfer those docs to `decimal` module or just remove it?