### PR TITLE
feat: adding in support for commas 

### DIFF
--- a/decimal.go
+++ b/decimal.go
@@ -132,6 +132,7 @@ func NewFromString(value string) (Decimal, error) {
 	var intString string
 	var exp int64
 
+	value = strings.Replace(value, ",", "", -1)
 	// Check if number is using scientific notation
 	eIndex := strings.IndexAny(value, "Ee")
 	if eIndex != -1 {

--- a/decimal_test.go
+++ b/decimal_test.go
@@ -317,6 +317,7 @@ func TestNewFromStringDeepEquals(t *testing.T) {
 		{"10", "10.0", false},
 		{"1.1", "1.10", false},
 		{"1.001", "1.01", false},
+		{"12,000.00", "12000.00", true},
 	}
 
 	for _, cmp := range tests {


### PR DESCRIPTION
We have a situation where we are reading in values from a CSV using gocsv, we would like to have support for stripping out commas from numbers. We believe this is reasonable support since having numbers with commas is a reasonable annotation to numbers.

Would love to hear your thoughts or if my additional of a test is not satisfactory, let me know!