### PR TITLE
Implement new initialization function - NewFromFormattedString

### DIFF
--- a/decimal.go
+++ b/decimal.go
@@ -178,19 +178,19 @@ func NewFromString(value string) (Decimal, error) {
 }
 
 // NewFromFormattedString returns a new Decimal from a formatted string representation.
-// The second argument - replRegexp, is a regexp rule that is used for matching characters occurrences that should
-// be removed from the decimal string representation. All matched characters will be replaced with an empty string.
+// The second argument - replRegexp, is a regular expression that is used to find characters that should be
+// removed from given decimal string representation. All matched characters will be replaced with an empty string.
 //
 // Example:
 //
 //     r := regexp.MustCompile("[$,]")
-// 	   d1, err := NewFromFormattedString("$5,125.99", r)
+//     d1, err := NewFromFormattedString("$5,125.99", r)
 //
 //     r2 := regexp.MustCompile("[_]")
-// 	   d2, err := NewFromFormattedString("1_000_000", r2)
+//     d2, err := NewFromFormattedString("1_000_000", r2)
 //
 //     r3 := regexp.MustCompile("[USD\\s]")
-// 	   d3, err := NewFromFormattedString("5000 USD", r3)
+//     d3, err := NewFromFormattedString("5000 USD", r3)
 //
 func NewFromFormattedString(value string, replRegexp *regexp.Regexp) (Decimal, error) {
 	parsedValue := replRegexp.ReplaceAllString(value, "")

--- a/decimal.go
+++ b/decimal.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"math"
 	"math/big"
+	"regexp"
 	"strconv"
 	"strings"
 )
@@ -174,6 +175,30 @@ func NewFromString(value string) (Decimal, error) {
 		value: dValue,
 		exp:   int32(exp),
 	}, nil
+}
+
+// NewFromFormattedString returns a new Decimal from a formatted string representation.
+// The second argument - replRegexp, is a regexp rule that is used for matching characters occurrences that should
+// be removed from the decimal string representation. All matched characters will be replaced with an empty string.
+//
+// Example:
+//
+//     r := regexp.MustCompile("[$,]")
+// 	   d1, err := NewFromFormattedString("$5,125.99", r)
+//
+//     r2 := regexp.MustCompile("[_]")
+// 	   d2, err := NewFromFormattedString("1_000_000", r2)
+//
+//     r3 := regexp.MustCompile("[USD\\s]")
+// 	   d3, err := NewFromFormattedString("5000 USD", r3)
+//
+func NewFromFormattedString(value string, replRegexp *regexp.Regexp) (Decimal, error) {
+	parsedValue := replRegexp.ReplaceAllString(value, "")
+	d, err := NewFromString(parsedValue)
+	if err != nil {
+		return Decimal{}, err
+	}
+	return d, nil
 }
 
 // RequireFromString returns a new Decimal from a string representation


### PR DESCRIPTION
#### Motivation: 
This new init function was requested more than 3 times (#98 #145 #183), so I thought it's the time we should implement such functionality. Also, personally I think it would be a great addition to the library too.

#### Implementation:
Implementation is pretty straight-forward. `NewFromFormattedString` is a wrapper around `NewFromString`, but before passing the value to mentioned before the init function we replace all characters matched by `replRegexp` with empty string `""`. I found this approach the most flexible and appealing for the user of the decimal library. I gathered opinions from my friends and they also agree with me. 
I may be wrong, but I think it's a much better approach than creating a init function with any other additional arguments such as: `thousandsSeparator` and/or `prefixToRemove`, etc. `replRegex` gives a lot of freedom and flexibility to the users of this library without adding dozens of arguments to the function signature that they probably don't need. 