### PR TITLE
Added power support for the travis.yml file with ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: go
+
 arch: 
  - amd64
  - ppc64le
+
 go:
   - 1.7.x
   - 1.12.x

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: go
-
+arch: 
+ - amd64
+ - ppc64le
 go:
   - 1.7.x
   - 1.12.x


### PR DESCRIPTION
Added power support for the travis.yml file with ppc64le. This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing