### PR TITLE
optimize NewFromString a bit

### DIFF
--- a/decimal_bench_test.go
+++ b/decimal_bench_test.go
@@ -1,6 +1,7 @@
 package decimal
 
 import (
+	"fmt"
 	"math"
 	"math/rand"
 	"sort"
@@ -181,5 +182,25 @@ func BenchmarkDecimal_IsInteger(b *testing.B) {
 	b.StartTimer()
 	for i := 0; i < b.N; i++ {
 		d.IsInteger()
+	}
+}
+
+func BenchmarkDecimal_NewFromString(b *testing.B) {
+	count := 72
+	prices := make([]string, 0, count)
+	for i := 1; i <= count; i++ {
+		prices = append(prices, fmt.Sprintf("%d.%d", i*100, i))
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for _, p := range prices {
+			d, err := NewFromString(p)
+			if err != nil {
+				b.Log(d)
+				b.Error(err)
+			}
+		}
 	}
 }

--- a/decimal_bench_test.go
+++ b/decimal_bench_test.go
@@ -204,3 +204,23 @@ func BenchmarkDecimal_NewFromString(b *testing.B) {
 		}
 	}
 }
+
+func BenchmarkDecimal_NewFromString_large_number(b *testing.B) {
+	count := 72
+	prices := make([]string, 0, count)
+	for i := 1; i <= count; i++ {
+		prices = append(prices, "9323372036854775807.9223372036854775807")
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for _, p := range prices {
+			d, err := NewFromString(p)
+			if err != nil {
+				b.Log(d)
+				b.Error(err)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Hi, while looking through the code, I noticed a string split being used and thought I'd make a pr for optimizing the parsing of a string a bit.

original:
```
goos: darwin
goarch: amd64
pkg: github.com/shopspring/decimal
BenchmarkDecimal_NewFromString_large_number
BenchmarkDecimal_NewFromString_large_number-12    	   23740	     50176 ns/op	   14400 B/op	     432 allocs/op
PASS

goos: darwin
goarch: amd64
pkg: github.com/shopspring/decimal
BenchmarkDecimal_NewFromString
BenchmarkDecimal_NewFromString-12    	   48504	     24745 ns/op	    8064 B/op	     360 allocs/op
PASS
```

new numbers 

for large numbers:
```
goos: darwin
goarch: amd64
pkg: github.com/shopspring/decimal
BenchmarkDecimal_NewFromString_large_number
BenchmarkDecimal_NewFromString_large_number-12    	   27516	     43336 ns/op	   12096 B/op	     360 allocs/op
PASS
```

optimization for smaller numbers:
```
goos: darwin
goarch: amd64
pkg: github.com/shopspring/decimal
BenchmarkDecimal_NewFromString
BenchmarkDecimal_NewFromString-12    	  102325	     11520 ns/op	    3456 B/op	     216 allocs/op
PASS
```