### PR TITLE
Unmarshal empty JSON string to Zero.

### DIFF
--- a/decimal.go
+++ b/decimal.go
@@ -1074,6 +1074,11 @@ func (d *Decimal) UnmarshalJSON(decimalBytes []byte) error {
 		return fmt.Errorf("error decoding string '%s': %s", decimalBytes, err)
 	}
 
+	if str == `""` {
+		*d = NewFromInt(0)
+		return nil
+	}
+
 	decimal, err := NewFromString(str)
 	*d = decimal
 	if err != nil {

--- a/decimal_test.go
+++ b/decimal_test.go
@@ -294,7 +294,6 @@ func TestFloat64(t *testing.T) {
 
 func TestNewFromStringErrs(t *testing.T) {
 	tests := []string{
-		"",
 		"qwert",
 		"-",
 		".",
@@ -596,14 +595,19 @@ func TestUnmarshalJSONNull(t *testing.T) {
 	var doc struct {
 		Amount Decimal `json:"amount"`
 	}
-	docStr := `{"amount": null}`
-	err := json.Unmarshal([]byte(docStr), &doc)
-	if err != nil {
-		t.Errorf("error unmarshaling %s: %v", docStr, err)
-	} else if !doc.Amount.Equal(Zero) {
-		t.Errorf("expected Zero, got %s (%s, %d)",
-			doc.Amount.String(),
-			doc.Amount.value.String(), doc.Amount.exp)
+	docStrings := []string{
+		`{"amount": null}`,
+		`{"amount": ""}`,
+	}
+	for _, docStr := range docStrings {
+		err := json.Unmarshal([]byte(docStr), &doc)
+		if err != nil {
+			t.Errorf("error unmarshaling %s: %v", docStr, err)
+		} else if !doc.Amount.Equal(Zero) {
+			t.Errorf("expected Zero, got %s (%s, %d)",
+				doc.Amount.String(),
+				doc.Amount.value.String(), doc.Amount.exp)
+		}
 	}
 }
 
@@ -612,7 +616,6 @@ func TestBadJSON(t *testing.T) {
 		"]o_o[",
 		"{",
 		`{"amount":""`,
-		`{"amount":""}`,
 		`{"amount":"nope"}`,
 		`0.333`,
 	} {
@@ -704,7 +707,6 @@ func TestNullDecimalBadJSON(t *testing.T) {
 		"]o_o[",
 		"{",
 		`{"amount":""`,
-		`{"amount":""}`,
 		`{"amount":"nope"}`,
 		`{"amount":nope}`,
 		`0.333`,


### PR DESCRIPTION
Some systems of unspoken horror may return an empty string when they meant Zero. This change lets the package be more permissive on its input regarding empty JSON string.