### PR TITLE
Add slice range checks to `UnmarshalBinary()`.

### DIFF
--- a/decimal.go
+++ b/decimal.go
@@ -1164,7 +1164,7 @@ func (d *Decimal) UnmarshalBinary(data []byte) error {
 	// Extract the value
 	d.value = new(big.Int)
 	if err := d.value.GobDecode(data[4:]); err != nil {
-		return fmt.Errorf("error decoding binary %v: %w", data, err)
+		return fmt.Errorf("error decoding binary %v: %s", data, err)
 	}
 
 	return nil

--- a/decimal.go
+++ b/decimal.go
@@ -1152,12 +1152,22 @@ func (d Decimal) MarshalJSON() ([]byte, error) {
 // UnmarshalBinary implements the encoding.BinaryUnmarshaler interface. As a string representation
 // is already used when encoding to text, this method stores that string as []byte
 func (d *Decimal) UnmarshalBinary(data []byte) error {
+	// Verify we have at least 5 bytes, 4 for the exponent and at least 1 more
+	// for the GOB encoded value.
+	if len(data) < 5 {
+		return fmt.Errorf("error decoding binary %v: expected at least 5 bytes, got %d", data, len(data))
+	}
+
 	// Extract the exponent
 	d.exp = int32(binary.BigEndian.Uint32(data[:4]))
 
 	// Extract the value
 	d.value = new(big.Int)
-	return d.value.GobDecode(data[4:])
+	if err := d.value.GobDecode(data[4:]); err != nil {
+		return fmt.Errorf("error decoding binary %v: %w", data, err)
+	}
+
+	return nil
 }
 
 // MarshalBinary implements the encoding.BinaryMarshaler interface.

--- a/decimal_test.go
+++ b/decimal_test.go
@@ -2798,6 +2798,24 @@ func TestBinary(t *testing.T) {
 	}
 }
 
+func TestBinary_DataTooShort(t *testing.T) {
+	var d Decimal
+
+	err := d.UnmarshalBinary(nil) // nil slice has length 0
+	if err == nil {
+		t.Fatalf("expected error, got %v", d)
+	}
+}
+
+func TestBinary_InvalidValue(t *testing.T) {
+	var d Decimal
+
+	err := d.UnmarshalBinary([]byte{0, 0, 0, 0, 'x'}) // valid exponent, invalid value
+	if err == nil {
+		t.Fatalf("expected error, got %v", d)
+	}
+}
+
 func slicesEqual(a, b []byte) bool {
 	for i, val := range a {
 		if b[i] != val {


### PR DESCRIPTION
This PR adds range checks to `Decimal.UnmarshalBinary()`, which prior to this PR would panic if `data` was less than 4 bytes in length.

For symmetry with other methods and this new error I've also added a little extra context to the error returned by `GobDecode()`, to make it clear it occurred within `UnmarshalBinary()`.

This addresses https://github.com/shopspring/decimal/issues/231.