### PR TITLE
add NewNullDecimal

### DIFF
--- a/decimal.go
+++ b/decimal.go
@@ -1411,6 +1411,13 @@ type NullDecimal struct {
 	Valid   bool
 }
 
+func NewNullDecimal(d Decimal) NullDecimal {
+	return NullDecimal{
+		Decimal: d,
+		Valid:   true,
+	}
+}
+
 // Scan implements the sql.Scanner interface for database deserialization.
 func (d *NullDecimal) Scan(value interface{}) error {
 	if value == nil {

--- a/decimal_test.go
+++ b/decimal_test.go
@@ -3081,6 +3081,18 @@ func TestTan(t *testing.T) {
 	}
 }
 
+func TestNewNullDecimal(t *testing.T) {
+	d := NewFromInt(1)
+	nd := NewNullDecimal(d)
+
+	if !nd.Valid {
+		t.FailNow()
+	}
+	if nd.Decimal != d {
+		t.FailNow()
+	}
+}
+
 func ExampleNewFromFloat32() {
 	fmt.Println(NewFromFloat32(123.123123123123).String())
 	fmt.Println(NewFromFloat32(.123123123123123).String())


### PR DESCRIPTION
Since `NullDecimal{d, true}` is discouraged (and static analysis tools like `go vet` will alert about it) adding `NewNullDecimal` seems like a nice way make code a bit more readable

```
nd := NewNullDecimal(d)
// vs
nd := NullDecimal{Decimal: d, Valid: true}
```