### PR TITLE
Add implementation of CoefficientInt64 method

### DIFF
--- a/decimal.go
+++ b/decimal.go
@@ -756,12 +756,18 @@ func (d Decimal) Exponent() int32 {
 	return d.exp
 }
 
-// Coefficient returns the coefficient of the decimal.  It is scaled by 10^Exponent()
+// Coefficient returns the coefficient of the decimal. It is scaled by 10^Exponent()
 func (d Decimal) Coefficient() *big.Int {
 	d.ensureInitialized()
-	// we copy the coefficient so that mutating the result does not mutate the
-	// Decimal.
+	// we copy the coefficient so that mutating the result does not mutate the Decimal.
 	return big.NewInt(0).Set(d.value)
+}
+
+// CoefficientInt64 returns the coefficient of the decimal as int64. It is scaled by 10^Exponent()
+// If coefficient cannot be represented in an int64, the result will be undefined.
+func (d Decimal) CoefficientInt64() int64 {
+	d.ensureInitialized()
+	return d.value.Int64()
 }
 
 // IntPart returns the integer component of the decimal.

--- a/decimal_test.go
+++ b/decimal_test.go
@@ -2643,6 +2643,36 @@ func TestDecimal_Coefficient(t *testing.T) {
 	}
 }
 
+func TestDecimal_CoefficientInt64(t *testing.T) {
+	type Inp struct {
+		Dec string
+		Coefficient int64
+	}
+
+	testCases := []Inp{
+		{"1", 1},
+		{"1.111", 1111},
+		{"1.000000", 1000000},
+		{"1.121215125511", 1121215125511},
+		{"100000000000000000", 100000000000000000},
+		{"9223372036854775807", 9223372036854775807},
+		{"10000000000000000000", -8446744073709551616}, // undefined value
+	}
+
+	// add negative cases
+	for _, tc := range testCases {
+		testCases = append(testCases, Inp{"-" + tc.Dec, -tc.Coefficient})
+	}
+
+	for _, tc := range testCases {
+		d := RequireFromString(tc.Dec)
+		coefficient := d.CoefficientInt64()
+		if coefficient != tc.Coefficient {
+			t.Errorf("expect coefficient %d, got %d, for decimal %s", tc.Coefficient, coefficient, tc.Dec)
+		}
+	}
+}
+
 func TestNullDecimal_Scan(t *testing.T) {
 	// test the Scan method that implements the
 	// sql.Scanner interface


### PR DESCRIPTION
Simple implementation of method that returns decimal's coefficient as `int64`. 
Reasoning and use cases covered in #237. 