### PR TITLE
method Ptr() for Decimal struct

### DIFF
--- a/decimal.go
+++ b/decimal.go
@@ -1424,6 +1424,11 @@ func (d Decimal) Value() (driver.Value, error) {
 	return d.String(), nil
 }
 
+// Decimal returns a pointer to struct
+func (d Decimal) Ptr() *Decimal {
+	return &d
+}
+
 // UnmarshalText implements the encoding.TextUnmarshaler interface for XML
 // deserialization.
 func (d *Decimal) UnmarshalText(text []byte) error {


### PR DESCRIPTION
In our projects we use this library and use type Decimal. But sometimes we need to have a pointer to this struct. Now if you want to create pointer to struct, you should create a variable and only then take address to this var. Using this method could do the same but using only one line. 