### PR TITLE
Trailing Zeros Config Added

### DIFF
--- a/decimal.go
+++ b/decimal.go
@@ -1465,7 +1465,11 @@ func (d Decimal) StringScaled(exp int32) string {
 
 func (d Decimal) string(trimTrailingZeros bool) string {
 	if d.exp >= 0 {
-		return d.rescale(0).value.String()
+		str := d.rescale(0).value.String()
+		if MarshalJSONWithoutTrailingZeros {
+			return str
+		}
+		return str + ".0"
 	}
 
 	abs := new(big.Int).Abs(d.value)

--- a/decimal.go
+++ b/decimal.go
@@ -1030,7 +1030,7 @@ func (d Decimal) String() string {
 
 func (d Decimal) marshalJsonString() string {
 	str := d.string(MarshalJSONWithoutTrailingZeros)
-	if !MarshalJSONWithoutTrailingZeros && !strings.Contains(str, ".") {
+	if !MarshalJSONWithoutTrailingZeros && d.exp >= 0 {
 		str += ".0"
 	}
 	return str

--- a/decimal.go
+++ b/decimal.go
@@ -1025,7 +1025,15 @@ func (d Decimal) InexactFloat64() float64 {
 //     -12.345
 //
 func (d Decimal) String() string {
-	return d.string(MarshalJSONWithoutTrailingZeros)
+	return d.string(true)
+}
+
+func (d Decimal) marshalJsonString() string {
+	str := d.string(MarshalJSONWithoutTrailingZeros)
+	if !MarshalJSONWithoutTrailingZeros && !strings.Contains(str, ".") {
+		str += ".0"
+	}
+	return str
 }
 
 // StringFixed returns a rounded fixed-point string with places digits after
@@ -1346,9 +1354,9 @@ func (d *Decimal) UnmarshalJSON(decimalBytes []byte) error {
 func (d Decimal) MarshalJSON() ([]byte, error) {
 	var str string
 	if MarshalJSONWithoutQuotes {
-		str = d.String()
+		str = d.marshalJsonString()
 	} else {
-		str = "\"" + d.String() + "\""
+		str = "\"" + d.marshalJsonString() + "\""
 	}
 	return []byte(str), nil
 }
@@ -1465,11 +1473,7 @@ func (d Decimal) StringScaled(exp int32) string {
 
 func (d Decimal) string(trimTrailingZeros bool) string {
 	if d.exp >= 0 {
-		str := d.rescale(0).value.String()
-		if MarshalJSONWithoutTrailingZeros {
-			return str
-		}
-		return str + ".0"
+		return d.rescale(0).value.String()
 	}
 
 	abs := new(big.Int).Abs(d.value)

--- a/decimal.go
+++ b/decimal.go
@@ -52,8 +52,8 @@ var DivisionPrecision = 16
 // silently lose precision.
 var MarshalJSONWithoutQuotes = false
 
-// MarshalJSONWithTrailingZeros should be set to true if you want to keep trailing zeros
-var MarshalJSONWithTrailingZeros = false
+// MarshalJSONWithoutTrailingZeros should be set to true if you want to keep trailing zeros
+var MarshalJSONWithoutTrailingZeros = true
 
 // ExpMaxIterations specifies the maximum number of iterations needed to calculate
 // precise natural exponent value using ExpHullAbrham method.
@@ -1025,7 +1025,7 @@ func (d Decimal) InexactFloat64() float64 {
 //     -12.345
 //
 func (d Decimal) String() string {
-	return d.string(true)
+	return d.string(MarshalJSONWithoutTrailingZeros)
 }
 
 // StringFixed returns a rounded fixed-point string with places digits after
@@ -1486,7 +1486,7 @@ func (d Decimal) string(trimTrailingZeros bool) string {
 		fractionalPart = strings.Repeat("0", num0s) + str
 	}
 
-	if trimTrailingZeros && !MarshalJSONWithTrailingZeros {
+	if trimTrailingZeros {
 		i := len(fractionalPart) - 1
 		for ; i >= 0; i-- {
 			if fractionalPart[i] != '0' {

--- a/decimal.go
+++ b/decimal.go
@@ -52,6 +52,9 @@ var DivisionPrecision = 16
 // silently lose precision.
 var MarshalJSONWithoutQuotes = false
 
+// MarshalJSONWithTrailingZeros should be set to true if you want to keep trailing zeros
+var MarshalJSONWithTrailingZeros = false
+
 // ExpMaxIterations specifies the maximum number of iterations needed to calculate
 // precise natural exponent value using ExpHullAbrham method.
 var ExpMaxIterations = 1000
@@ -1483,7 +1486,7 @@ func (d Decimal) string(trimTrailingZeros bool) string {
 		fractionalPart = strings.Repeat("0", num0s) + str
 	}
 
-	if trimTrailingZeros {
+	if trimTrailingZeros && !MarshalJSONWithTrailingZeros {
 		i := len(fractionalPart) - 1
 		for ; i >= 0; i-- {
 			if fractionalPart[i] != '0' {

--- a/decimal.go
+++ b/decimal.go
@@ -52,7 +52,7 @@ var DivisionPrecision = 16
 // silently lose precision.
 var MarshalJSONWithoutQuotes = false
 
-// MarshalJSONWithoutTrailingZeros should be set to true if you want to keep trailing zeros
+// MarshalJSONWithoutTrailingZeros should be set to false if you want to keep trailing zeros
 var MarshalJSONWithoutTrailingZeros = true
 
 // ExpMaxIterations specifies the maximum number of iterations needed to calculate

--- a/decimal_test.go
+++ b/decimal_test.go
@@ -3320,6 +3320,25 @@ func TestNewNullDecimal(t *testing.T) {
 	}
 }
 
+func TestTrailingZeros(t *testing.T) {
+	MarshalJSONWithoutQuotes = true
+	MarshalJSONWithTrailingZeros = true
+	var doc struct {
+		Amount Decimal `json:"amount"`
+	}
+
+	doc.Amount = New(100, -2)
+	b, err := json.Marshal(&doc)
+	if err != nil {
+		t.FailNow()
+	}
+
+	docStr := `{"amount":1.00}`
+	if string(b) != docStr {
+		t.Errorf("expected %s, got %s", docStr, b)
+	}
+}
+
 func ExampleNewFromFloat32() {
 	fmt.Println(NewFromFloat32(123.123123123123).String())
 	fmt.Println(NewFromFloat32(.123123123123123).String())

--- a/decimal_test.go
+++ b/decimal_test.go
@@ -3339,6 +3339,20 @@ func TestTrailingZeros(t *testing.T) {
 	}
 }
 
+func TestTrailingZerosA(t *testing.T) {
+	MarshalJSONWithoutTrailingZeros = false
+	v := New(100, 0)
+	str := v.String()
+	if str != "100.0" {
+		t.Errorf("expected %s, got %s", "100.0", str)
+	}
+	MarshalJSONWithoutTrailingZeros = true
+	str = v.String()
+	if str != "100" {
+		t.Errorf("expected %s, got %s", "100", str)
+	}
+}
+
 func ExampleNewFromFloat32() {
 	fmt.Println(NewFromFloat32(123.123123123123).String())
 	fmt.Println(NewFromFloat32(.123123123123123).String())

--- a/decimal_test.go
+++ b/decimal_test.go
@@ -3322,7 +3322,7 @@ func TestNewNullDecimal(t *testing.T) {
 
 func TestTrailingZeros(t *testing.T) {
 	MarshalJSONWithoutQuotes = true
-	MarshalJSONWithTrailingZeros = true
+	MarshalJSONWithoutTrailingZeros = false
 	var doc struct {
 		Amount Decimal `json:"amount"`
 	}

--- a/decimal_test.go
+++ b/decimal_test.go
@@ -3339,7 +3339,7 @@ func TestTrailingZeros(t *testing.T) {
 	}
 }
 
-func TestTrailingZerosA(t *testing.T) {
+func TestTrailingZerosWithIntValue(t *testing.T) {
 	MarshalJSONWithoutTrailingZeros = false
 	v := New(100, 0)
 	str := v.String()


### PR DESCRIPTION
### why ?
In our project we are removing trailing zeros up to certain point and we need trailing zeros. Thats why we need to marshal the decimal value with some trailing zeros in order to keep our format. There is no config for this. It removes trailing zeros. In MarshalJSON function String method is called.
### what changed ?
 - new global config added for trailing zeros
 ```go
 // MarshalJSONWithoutTrailingZeros should be set to false if you want to keep trailing zeros
var MarshalJSONWithoutTrailingZeros = true

func (d Decimal) marshalJsonString() string {
	str := d.string(MarshalJSONWithoutTrailingZeros)
	if !MarshalJSONWithoutTrailingZeros && !strings.Contains(str, ".") {
		str += ".0"
	}
	return str
}

func (d Decimal) MarshalJSON() ([]byte, error) {
	var str string
	if MarshalJSONWithoutQuotes {
		str = d.marshalJsonString() // method changed
	} else {
		str = "\"" + d.marshalJsonString() + "\"" // method changed
	}
	return []byte(str), nil
}
 ```