### PR TITLE
removed min() function for RescalePair()

### DIFF
--- a/decimal.go
+++ b/decimal.go
@@ -458,9 +458,9 @@ func (d Decimal) rescale(exp int32) Decimal {
 	value := new(big.Int).Set(d.value)
 
 	expScale := new(big.Int).Exp(tenInt, big.NewInt(int64(diff)), nil)
-	if exp > d.exp {
+	if exp < d.exp {
 		value = value.Quo(value, expScale)
-	} else if exp < d.exp {
+	} else if exp > d.exp {
 		value = value.Mul(value, expScale)
 	}
 

--- a/decimal.go
+++ b/decimal.go
@@ -458,9 +458,9 @@ func (d Decimal) rescale(exp int32) Decimal {
 	value := new(big.Int).Set(d.value)
 
 	expScale := new(big.Int).Exp(tenInt, big.NewInt(int64(diff)), nil)
-	if exp < d.exp {
+	if exp > d.exp {
 		value = value.Quo(value, expScale)
-	} else if exp > d.exp {
+	} else if exp < d.exp {
 		value = value.Mul(value, expScale)
 	}
 
@@ -1567,9 +1567,9 @@ func RescalePair(d1 Decimal, d2 Decimal) (Decimal, Decimal) {
 	d1.ensureInitialized()
 	d2.ensureInitialized()
 
-	if d1.exp > d2.exp {
+	if d1.exp < d2.exp {
 		return d1, d2.rescale(d1.exp)
-	} else if d1.exp < d2.exp {
+	} else if d1.exp > d2.exp {
 		return d1.rescale(d2.exp), d2
 	}
 

--- a/decimal.go
+++ b/decimal.go
@@ -1567,22 +1567,13 @@ func RescalePair(d1 Decimal, d2 Decimal) (Decimal, Decimal) {
 	d1.ensureInitialized()
 	d2.ensureInitialized()
 
-	if d1.exp == d2.exp {
-		return d1, d2
+	if d1.exp > d2.exp {
+		return d1, d2.rescale(d1.exp)
+	} else if d1.exp < d2.exp {
+		return d1.rescale(d2.exp), d2
 	}
 
-	baseScale := min(d1.exp, d2.exp)
-	if baseScale != d1.exp {
-		return d1.rescale(baseScale), d2
-	}
-	return d1, d2.rescale(baseScale)
-}
-
-func min(x, y int32) int32 {
-	if x >= y {
-		return y
-	}
-	return x
+	return d1, d2
 }
 
 func unquoteIfQuoted(value interface{}) (string, error) {


### PR DESCRIPTION
Removing the `min()` func from `RescalePair()` stops the copy operation for passing the values into `min()` saving on the bytes per op and marginal decreases in runtime. For fun I implemented the new implementation into a new `Add()` func and it looks like the effect is doubled.

```
goos: windows
goarch: amd64
pkg: github.com/shopspring/decimal
cpu: Intel(R) Core(TM) i5-3550 CPU @ 3.30GHz

BenchmarkRescalePairGreaterThan-4      	 3631178	       333.6 ns/op	     200 B/op	       7 allocs/op
BenchmarkRescalePairLessThan-4         	 3669758	       336.1 ns/op	     200 B/op	       7 allocs/op
BenchmarkRescalePairEqual-4            	261132116	         4.714 ns/op	       0 B/op	       0 allocs/op

BenchmarkNewRescalePairGreaterThan-4   	 3847358	       329.0 ns/op	     160 B/op	       7 allocs/op
BenchmarkNewRescalePairLessThan-4      	 3669552	       318.7 ns/op	     160 B/op	       7 allocs/op
BenchmarkNewRescalePairEqual-4         	255000668	         4.692 ns/op	       0 B/op	       0 allocs/op

BenchmarkAddGreaterThan-4              	 2455047	       428.4 ns/op	     280 B/op	       9 allocs/op
BenchmarkAddLessThan-4                 	 2711714	       430.2 ns/op	     280 B/op	       9 allocs/op
BenchmarkAddEqual-4                    	11634004	       100.4 ns/op	      80 B/op	       2 allocs/op

BenchmarkNewAddGreaterThan-4           	 2999233	       400.4 ns/op	     200 B/op	       9 allocs/op
BenchmarkNewAddLessThan-4              	 2975070	       402.1 ns/op	     200 B/op	       9 allocs/op
BenchmarkNewAddEqual-4                 	13229145	        97.82 ns/op	      80 B/op	       2 allocs/op
```