### PR TITLE
Allocate new(big.Int) in Copy method to deeply clone it

### DIFF
--- a/decimal.go
+++ b/decimal.go
@@ -418,7 +418,7 @@ func NewFromFloatWithExponent(value float64, exp int32) Decimal {
 func (d Decimal) Copy() Decimal {
 	d.ensureInitialized()
 	return Decimal{
-		value: &(*d.value),
+		value: new(big.Int).Set(d.value),
 		exp:   d.exp,
 	}
 }

--- a/decimal_test.go
+++ b/decimal_test.go
@@ -560,6 +560,10 @@ func TestCopy(t *testing.T) {
 	origin := New(1, 0)
 	cpy := origin.Copy()
 
+	if origin.value == cpy.value {
+		t.Error("expecting copy and origin to have different value pointers")
+	}
+
 	if cpy.Cmp(origin) != 0 {
 		t.Error("expecting copy and origin to be equals, but they are not")
 	}


### PR DESCRIPTION
This is necessary to match the description of big.Int: https://pkg.go.dev/math/big#Int
```
  To "copy" an Int value,
  an existing (or newly allocated) Int must be set to
  a new value using the Int.Set method; shallow copies
  of Ints are not supported and may lead to errors.
```