### PR TITLE
Add NewFromBigRat function

### DIFF
--- a/decimal.go
+++ b/decimal.go
@@ -125,7 +125,7 @@ func NewFromBigInt(value *big.Int, exp int32) Decimal {
 	}
 }
 
-// NewFromBigRat returns a new Decimal from a big.Rat. The nominator and
+// NewFromBigRat returns a new Decimal from a big.Rat. The numerator and
 // denominator are divided and rounded to the given precision.
 //
 // Example:

--- a/decimal.go
+++ b/decimal.go
@@ -130,9 +130,10 @@ func NewFromBigInt(value *big.Int, exp int32) Decimal {
 //
 // Example:
 //
-//     d1, err := NewFromBigRat(big.NewRat(0, 1), 4)
-//     d2, err := NewFromBigRat(big.NewRat(4, 5), 100)
-//     d3, err := NewFromBigRat(big.NewRat(10000, 3), 300)
+//     d1 := NewFromBigRat(big.NewRat(0, 1), 0)    // output: "0"
+//     d2 := NewFromBigRat(big.NewRat(4, 5), 1)    // output: "0.8"
+//     d3 := NewFromBigRat(big.NewRat(1000, 3), 3) // output: "333.333"
+//     d4 := NewFromBigRat(big.NewRat(2, 7), 4)    // output: "0.2857"
 //
 func NewFromBigRat(value *big.Rat, precision int32) Decimal {
 	return Decimal{

--- a/decimal.go
+++ b/decimal.go
@@ -125,6 +125,25 @@ func NewFromBigInt(value *big.Int, exp int32) Decimal {
 	}
 }
 
+// NewFromBigRat returns a new Decimal from a big.Rat. The nominator and
+// denominator are divided and rounded to the given precision.
+//
+// Example:
+//
+//     d1, err := NewFromBigRat(big.NewRat(0, 1), 4)
+//     d2, err := NewFromBigRat(big.NewRat(4, 5), 100)
+//     d3, err := NewFromBigRat(big.NewRat(10000, 3), 300)
+//
+func NewFromBigRat(value *big.Rat, precision int32) Decimal {
+	return Decimal{
+		value: new(big.Int).Set(value.Num()),
+		exp:   0,
+	}.DivRound(Decimal{
+		value: new(big.Int).Set(value.Denom()),
+		exp:   0,
+	}, precision)
+}
+
 // NewFromString returns a new Decimal from a string representation.
 // Trailing zeroes are not trimmed.
 //


### PR DESCRIPTION
This adds a convenience helper function that converts a `big.Rat` to a `Decimal`. Since it is impossible to guarantee an exact accuracy, a precision attribute is used.

Just as the `Div` method has a `DivRounded` method counterpart, perhaps this convenience function should have one as well? It could use the `DivisionPrecision` variable and wouldn't accept a precision parameter.
