### PR TITLE
Fix NumDigits with ensureInitialized

### DIFF
--- a/decimal.go
+++ b/decimal.go
@@ -815,6 +815,7 @@ func (d Decimal) ExpTaylor(precision int32) (Decimal, error) {
 // NumDigits returns the number of digits of the decimal coefficient (d.Value)
 // Note: Current implementation is extremely slow for large decimals and/or decimals with large fractional part
 func (d Decimal) NumDigits() int {
+	d.ensureInitialized()
 	// Note(mwoss): It can be optimized, unnecessary cast of big.Int to string
 	if d.IsNegative() {
 		return len(d.value.String()) - 1

--- a/decimal_test.go
+++ b/decimal_test.go
@@ -2764,6 +2764,7 @@ func TestDecimal_NumDigits(t *testing.T) {
 		{"-5.26", 3},
 		{"-5.2663117716", 11},
 		{"-26.1", 3},
+		{"", 1},
 	} {
 		d, _ := NewFromString(testCase.Dec)
 


### PR DESCRIPTION
Fix #292 

The library promises

> The zero-value is 0, and is safe to use without initialization

Simply add `ensureInitialized` at the beginning of `NumDigits` to ensure zero-value act as `NewFromInt(0)`.