### PR TITLE
Support for the three latest Go version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ '1.7.x', '1.15', '1.16', '1.17', '1.x' ]
+        go: [ '1.17', '1.18', '1.19', '1.x' ]
     name: Go ${{ matrix.go }}
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Run `go get github.com/shopspring/decimal`
 
 ## Requirements 
 
-Decimal library requires Go version `>=1.7`
+Decimal library requires Go version `>=1.17`
 
 ## Usage
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/shopspring/decimal
 
-go 1.13
+go 1.19


### PR DESCRIPTION
I use this module on production a long time. I happened to find the Go versions are old. This PR update Go version on CI and go.mod. And, I also update README.md.