### PR TITLE
Update Github Actions libraries to latest working version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,16 +1,16 @@
-name: decimal-ci
+name: ci
 on: [push]
 jobs:
   ci-job:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ '1.7.x', '1.15', '1.16', '1.17', '1.x' ]
+        go: [ '1.7.x', '1.18', '1.19', '1.20', '1.21', '1.x' ]
     name: Go ${{ matrix.go }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Use go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go }}
       - run: go build .

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # decimal
 
-[![Github Actions](https://github.com/shopspring/decimal/actions/workflows/ci.yml/badge.svg)](https://github.com/shopspring/decimal/actions/workflows/ci.yml)
+[![ci](https://github.com/shopspring/decimal/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/shopspring/decimal/actions/workflows/ci.yml)
 [![GoDoc](https://godoc.org/github.com/shopspring/decimal?status.svg)](https://godoc.org/github.com/shopspring/decimal) 
 [![Go Report Card](https://goreportcard.com/badge/github.com/shopspring/decimal)](https://goreportcard.com/report/github.com/shopspring/decimal)
 


### PR DESCRIPTION
As in the title, the old version of used libs (mainly go-setup) stopped working with minimal required versions of Go - 1.7. Update to latest version fixed the issue :3 