### PR TITLE
feat: add Compare method which forwards calls to Cmp

### DIFF
--- a/decimal.go
+++ b/decimal.go
@@ -981,6 +981,15 @@ func (d Decimal) Cmp(d2 Decimal) int {
 	return rd.value.Cmp(rd2.value)
 }
 
+// Compare compares the numbers represented by d and d2 and returns:
+//
+//	-1 if d <  d2
+//	 0 if d == d2
+//	+1 if d >  d2
+func (d Decimal) Compare(d2 Decimal) int {
+	return d.Cmp(d2)
+}
+
 // Equal returns whether the numbers represented by d and d2 are equal.
 func (d Decimal) Equal(d2 Decimal) bool {
 	return d.Cmp(d2) == 0


### PR DESCRIPTION
Given the interface definition

	type Ordered[T any] interface {
		Compare(T) int
	}

And the type constraint T Ordered[T], make decimal.Decimal satisfy this constraint, so that generic code written against T Ordered[T] can work with decimal values as smoothly as it works with time.Time values today.

Fixes: #345