### PR TITLE
Add improved implementation of power operation

### DIFF
--- a/decimal_bench_test.go
+++ b/decimal_bench_test.go
@@ -3,6 +3,7 @@ package decimal
 import (
 	"fmt"
 	"math"
+	"math/big"
 	"math/rand"
 	"sort"
 	"strconv"
@@ -182,6 +183,41 @@ func BenchmarkDecimal_IsInteger(b *testing.B) {
 	b.StartTimer()
 	for i := 0; i < b.N; i++ {
 		d.IsInteger()
+	}
+}
+
+func BenchmarkDecimal_Pow(b *testing.B) {
+	d1 := RequireFromString("5.2")
+	d2 := RequireFromString("6.3")
+
+	for i := 0; i < b.N; i++ {
+		d1.Pow(d2)
+	}
+}
+
+func BenchmarkDecimal_PowWithPrecision(b *testing.B) {
+	d1 := RequireFromString("5.2")
+	d2 := RequireFromString("6.3")
+
+	for i := 0; i < b.N; i++ {
+		_, _ = d1.PowWithPrecision(d2, 8)
+	}
+}
+func BenchmarkDecimal_PowInt32(b *testing.B) {
+	d1 := RequireFromString("5.2")
+	d2 := int32(10)
+
+	for i := 0; i < b.N; i++ {
+		_, _ = d1.PowInt32(d2)
+	}
+}
+
+func BenchmarkDecimal_PowBigInt(b *testing.B) {
+	d1 := RequireFromString("5.2")
+	d2 := big.NewInt(10)
+
+	for i := 0; i < b.N; i++ {
+		_, _ = d1.PowBigInt(d2)
 	}
 }
 

--- a/decimal_test.go
+++ b/decimal_test.go
@@ -3673,15 +3673,3 @@ func ExampleNewFromFloat() {
 	//0.123123123123123
 	//-10000000000000
 }
-
-func TestXDD(t *testing.T) {
-	d1 := NewFromFloat(4.0)
-	d2 := NewFromFloat(4.0)
-	res1 := d1.Pow(d2)
-	t.Log(res1.String()) // output: "16.0"
-
-	d3 := NewFromFloat(5.0)
-	d4 := NewFromFloat(5.73)
-	res2 := d3.Pow(d4)
-	t.Log(res2.String()) // output: "10118.080371595015625"
-}


### PR DESCRIPTION
PR adds an improved implementation of the `Pow` method. It also adds three new methods - `PowWithPrecision`, `PowInt32`, and `PowBigInt`.
`PowWithPrecision` can be used for calculating powers with high, specific precision. `PowInt32` and `PowBigInt` can be used for more performant calculation of decimal powers in case the exponent is simply an integer.

It took me some time to implement them as it was quite a difficult task, especially when we care about correctness and high precision. I also had to implement natural exponent and natural logarithm implementation for that.