### PR TITLE
Run CI on both push to origin branches and pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 name: ci
-on: [push]
+on: [push, pull_request]
 jobs:
   ci-job:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: ci
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 jobs:
   ci-job:
     runs-on: ubuntu-latest


### PR DESCRIPTION
I was not aware that `pull_reuqest` was different than `push` in the context of creating a simple pull request to the origin repo. This fix should allow collaborators to trigger the CI.