### PR TITLE
Drop support for Go versions older than 1.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ '1.10.x', '1.18', '1.19', '1.20', '1.21', '1.22', '1.x' ]
+        go: [ '1.10.x', '1.19', '1.20', '1.21', '1.22', '1.x' ]
     name: Go ${{ matrix.go }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ '1.7.x', '1.18', '1.19', '1.20', '1.21', '1.x' ]
+        go: [ '1.10.x', '1.18', '1.19', '1.20', '1.21', '1.22', '1.x' ]
     name: Go ${{ matrix.go }}
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Run `go get github.com/shopspring/decimal`
 
 ## Requirements 
 
-Decimal library requires Go version `>=1.7`
+Decimal library requires Go version `>=1.10`
 
 ## Usage
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/shopspring/decimal
 
-go 1.7
+go 1.10


### PR DESCRIPTION
We decided to drop support for the Go versions older than 1.10  to use the new `big.Int` functionalities introduced in this Go version, thus improving the performance of critical paths/methods like `NumDigits`.
Go 1.10 is already 6 years old, so we believe this change won't affect most of the library users (+ Go compiler supports backward compatibility)