### PR TITLE
Remove production usage from docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,11 +63,6 @@ func main() {
 
 http://godoc.org/github.com/shopspring/decimal
 
-## Production Usage
-
-* [Spring](https://shopspring.com/), since August 14, 2014.
-* If you are using this in production, please let us know!
-
 ## FAQ
 
 #### Why don't you just use float64?


### PR DESCRIPTION
This part of docs is unnecessary. Spring is long ago gone, Shoprunner is no longer using Go as far as I know and it's pointless to track who is using this library in production - we are not a company seeking funding.