### PR TITLE
Add docs section with alternative libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Fortunately, thanks to the wonderful community we have a dozen other libraries t
 Explore other alternatives to find the one that best fits your needs :)  
 
 * [cockroachdb/apd](https://github.com/cockroachdb/apd) - high precision, mutable and rich API similar to `big.Int`, higher performance than this library 
-* [alpacahq/alpacadecimal](https://github.com/alpacahq/alpacadecimal) - high performance, low precision (12 digits), with fully compatible API to this library 
+* [alpacahq/alpacadecimal](https://github.com/alpacahq/alpacadecimal) - high performance, low precision (12 digits), fully compatible API with this library 
 * [govalues/decimal](https://github.com/govalues/decimal) - high performance, zero-allocation, low precision (19 digits)
 * [greatcloak/decimal](https://github.com/greatcloak/decimal) - fork of this library, with out-of-the-box BSON marshaling support
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@ Run `go get github.com/shopspring/decimal`
 
 Decimal library requires Go version `>=1.10`
 
+## Documentation
+
+http://godoc.org/github.com/shopspring/decimal
+
+
 ## Usage
 
 ```go
@@ -59,9 +64,16 @@ func main() {
 }
 ```
 
-## Documentation
+## Alternative libraries
 
-http://godoc.org/github.com/shopspring/decimal
+When working with decimal numbers, you might face problems this library is not perfectly suited for. 
+Fortunately, thanks to the wonderful community we have a dozen other libraries that you can choose from.  
+Explore other alternatives to find the one that best fits your needs :)  
+
+* [cockroachdb/apd](https://github.com/cockroachdb/apd) - high precision, mutable and rich API similar to `big.Int`, higher performance than this library 
+* [alpacahq/alpacadecimal](https://github.com/alpacahq/alpacadecimal) - high performance, low precision (12 digits), with fully compatible API to this library 
+* [govalues/decimal](https://github.com/govalues/decimal) - high performance, zero-allocation, low precision (19 digits)
+* [greatcloak/decimal](https://github.com/greatcloak/decimal) - fork of this library, with out-of-the-box BSON marshaling support
 
 ## FAQ
 

--- a/README.md
+++ b/README.md
@@ -70,10 +70,10 @@ When working with decimal numbers, you might face problems this library is not p
 Fortunately, thanks to the wonderful community we have a dozen other libraries that you can choose from.  
 Explore other alternatives to find the one that best fits your needs :)  
 
-* [cockroachdb/apd](https://github.com/cockroachdb/apd) - high precision, mutable and rich API similar to `big.Int`, more performant than this library 
+* [cockroachdb/apd](https://github.com/cockroachdb/apd) - arbitrary precision, mutable and rich API similar to `big.Int`, more performant than this library 
 * [alpacahq/alpacadecimal](https://github.com/alpacahq/alpacadecimal) - high performance, low precision (12 digits), fully compatible API with this library 
 * [govalues/decimal](https://github.com/govalues/decimal) - high performance, zero-allocation, low precision (19 digits)
-* [greatcloak/decimal](https://github.com/greatcloak/decimal) - fork of this library, with out-of-the-box BSON marshaling support
+* [greatcloak/decimal](https://github.com/greatcloak/decimal) - fork focusing on billing and e-commerce web application related use cases, includes out-of-the-box BSON marshaling support
 
 ## FAQ
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ When working with decimal numbers, you might face problems this library is not p
 Fortunately, thanks to the wonderful community we have a dozen other libraries that you can choose from.  
 Explore other alternatives to find the one that best fits your needs :)  
 
-* [cockroachdb/apd](https://github.com/cockroachdb/apd) - high precision, mutable and rich API similar to `big.Int`, higher performance than this library 
+* [cockroachdb/apd](https://github.com/cockroachdb/apd) - high precision, mutable and rich API similar to `big.Int`, better performance than this library 
 * [alpacahq/alpacadecimal](https://github.com/alpacahq/alpacadecimal) - high performance, low precision (12 digits), fully compatible API with this library 
 * [govalues/decimal](https://github.com/govalues/decimal) - high performance, zero-allocation, low precision (19 digits)
 * [greatcloak/decimal](https://github.com/greatcloak/decimal) - fork of this library, with out-of-the-box BSON marshaling support

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ When working with decimal numbers, you might face problems this library is not p
 Fortunately, thanks to the wonderful community we have a dozen other libraries that you can choose from.  
 Explore other alternatives to find the one that best fits your needs :)  
 
-* [cockroachdb/apd](https://github.com/cockroachdb/apd) - high precision, mutable and rich API similar to `big.Int`, better performance than this library 
+* [cockroachdb/apd](https://github.com/cockroachdb/apd) - high precision, mutable and rich API similar to `big.Int`, more performant than this library 
 * [alpacahq/alpacadecimal](https://github.com/alpacahq/alpacadecimal) - high performance, low precision (12 digits), fully compatible API with this library 
 * [govalues/decimal](https://github.com/govalues/decimal) - high performance, zero-allocation, low precision (19 digits)
 * [greatcloak/decimal](https://github.com/greatcloak/decimal) - fork of this library, with out-of-the-box BSON marshaling support


### PR DESCRIPTION
PR adds a new section to library docs - alternative libraries. The section briefly covers other alternatives created by the community. This can help other developers when they are looking for solution that fits their use cases the best :DD