### PR TITLE
Adds MarshalYAML for marshaling yaml

### DIFF
--- a/decimal.go
+++ b/decimal.go
@@ -1799,7 +1799,7 @@ func (d Decimal) MarshalJSON() ([]byte, error) {
 	return []byte(str), nil
 }
 
-// MarshalYAML implements the yaml.Marshaler interface.
+// MarshalYAML implements the [yaml.Marshaler] interface.
 func (d Decimal) MarshalYAML() (interface{}, error) {
 	if MarshalYAMLWithoutQuotes {
 		n := yaml.Node{

--- a/decimal.go
+++ b/decimal.go
@@ -1800,7 +1800,7 @@ func (d Decimal) MarshalJSON() ([]byte, error) {
 }
 
 // MarshalYAML implements the [yaml.Marshaler] interface.
-func (d Decimal) MarshalYAML() (interface{}, error) {
+func (d Decimal) MarshalYAML() (any, error) {
 	if MarshalYAMLWithoutQuotes {
 		n := yaml.Node{
 			Kind: yaml.ScalarNode,

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/shopspring/decimal
 
 go 1.10
+
+require gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/shopspring/decimal
 
-go 1.10
+go 1.18
 
 require gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,3 @@
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
When marshaling with go-yaml/yaml, numbers are output as double quoted strings.  This adds a custom marshaller (MarshalYAML) that respects a new variable MarshalYAMLWithoutQuotes.

If you decide that you don't want this, I'm happy for it to just live here as a closed PR for anyone else looking for how to do this on their own.