### PR TITLE
`UnmarshalJSON`, `Scan` and `NewFromString` performance improvements

### DIFF
--- a/decimal.go
+++ b/decimal.go
@@ -182,8 +182,23 @@ func NewFromString(value string) (Decimal, error) {
 	var intString string
 	var exp int64
 
-	// Check if number is using scientific notation
-	eIndex := strings.IndexAny(value, "Ee")
+	// Check if number is using scientific notation and find dots
+	eIndex := -1
+	pIndex := -1
+	for i, r := range value {
+		if eIndex == -1 && (r == 'E' || r == 'e') {
+			eIndex = i
+			continue
+		}
+
+		if r == '.' {
+			if pIndex > -1 {
+				return Decimal{}, fmt.Errorf("can't convert %s to decimal: too many .s", value)
+			}
+			pIndex = i
+		}
+	}
+
 	if eIndex != -1 {
 		expInt, err := strconv.ParseInt(value[eIndex+1:], 10, 32)
 		if err != nil {
@@ -196,23 +211,12 @@ func NewFromString(value string) (Decimal, error) {
 		exp = expInt
 	}
 
-	pIndex := -1
-	vLen := len(value)
-	for i := 0; i < vLen; i++ {
-		if value[i] == '.' {
-			if pIndex > -1 {
-				return Decimal{}, fmt.Errorf("can't convert %s to decimal: too many .s", value)
-			}
-			pIndex = i
-		}
-	}
-
 	if pIndex == -1 {
 		// There is no decimal point, we can just parse the original string as
 		// an int
 		intString = value
 	} else {
-		if pIndex+1 < vLen {
+		if pIndex+1 < len(value) {
 			intString = value[:pIndex] + value[pIndex+1:]
 		} else {
 			intString = value[:pIndex]
@@ -1766,15 +1770,10 @@ func (d *Decimal) UnmarshalJSON(decimalBytes []byte) error {
 		return nil
 	}
 
-	str, err := unquoteIfQuoted(decimalBytes)
-	if err != nil {
-		return fmt.Errorf("error decoding string '%s': %s", decimalBytes, err)
-	}
-
-	decimal, err := NewFromString(str)
+	decimal, err := NewFromString(unquoteIfQuoted(string(decimalBytes)))
 	*d = decimal
 	if err != nil {
-		return fmt.Errorf("error decoding string '%s': %s", str, err)
+		return fmt.Errorf("error decoding string '%s': %s", string(decimalBytes), err)
 	}
 	return nil
 }
@@ -1852,14 +1851,18 @@ func (d *Decimal) Scan(value interface{}) error {
 		*d = NewFromUint64(v)
 		return nil
 
-	default:
-		// default is trying to interpret value stored as string
-		str, err := unquoteIfQuoted(v)
-		if err != nil {
-			return err
-		}
-		*d, err = NewFromString(str)
+	case string:
+		var err error
+		*d, err = NewFromString(unquoteIfQuoted(v))
 		return err
+
+	case []byte:
+		var err error
+		*d, err = NewFromString(unquoteIfQuoted(string(v)))
+		return err
+
+	default:
+		return fmt.Errorf("could not convert value '%+v' to any known type", value)
 	}
 }
 
@@ -2021,23 +2024,13 @@ func RescalePair(d1 Decimal, d2 Decimal) (Decimal, Decimal) {
 	return d1, d2
 }
 
-func unquoteIfQuoted(value interface{}) (string, error) {
-	var bytes []byte
-
-	switch v := value.(type) {
-	case string:
-		bytes = []byte(v)
-	case []byte:
-		bytes = v
-	default:
-		return "", fmt.Errorf("could not convert value '%+v' to byte array of type '%T'", value, value)
-	}
-
+func unquoteIfQuoted(value string) string {
 	// If the amount is quoted, strip the quotes
-	if len(bytes) > 2 && bytes[0] == '"' && bytes[len(bytes)-1] == '"' {
-		bytes = bytes[1 : len(bytes)-1]
+	if len(value) > 2 && value[0] == '"' && value[len(value)-1] == '"' {
+		return value[1 : len(value)-1]
 	}
-	return string(bytes), nil
+
+	return value
 }
 
 // NullDecimal represents a nullable decimal with compatibility for

--- a/decimal_bench_test.go
+++ b/decimal_bench_test.go
@@ -312,3 +312,15 @@ func BenchmarkDecimal_ExpTaylor(b *testing.B) {
 		_, _ = d.ExpTaylor(10)
 	}
 }
+
+func BenchmarkDecimal_UnmarshalJSON(b *testing.B) {
+	b.ResetTimer()
+
+	bstr := []byte("1234.56789")
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = (&Decimal{}).UnmarshalJSON(bstr)
+	}
+}


### PR DESCRIPTION
This PR improves `UnmarshalJSON`  performance by reducing unnecessary allocation caused by `unquoteIfQuoted` function. This also touches on `Scan` method to split `default` case into `string` and `[]byte` cases.

This PR also slightly touches `NewFromString` function by making so scientific notation and dots are checked in a single loop.

Benchmarks:
Old:
```
goos: linux
goarch: amd64
pkg: github.com/shopspring/decimal
cpu: AMD Ryzen 7 7700X 8-Core Processor             
BenchmarkDecimal_UnmarshalJSON-16    	10973582	       105.5 ns/op	      96 B/op	       5 allocs/op
BenchmarkDecimal_UnmarshalJSON-16    	11399134	       103.7 ns/op	      96 B/op	       5 allocs/op
BenchmarkDecimal_UnmarshalJSON-16    	11480460	       103.4 ns/op	      96 B/op	       5 allocs/op
BenchmarkDecimal_UnmarshalJSON-16    	11440952	       103.6 ns/op	      96 B/op	       5 allocs/op
BenchmarkDecimal_UnmarshalJSON-16    	11305298	       103.2 ns/op	      96 B/op	       5 allocs/op
BenchmarkDecimal_UnmarshalJSON-16    	11353047	       102.5 ns/op	      96 B/op	       5 allocs/op
BenchmarkDecimal_UnmarshalJSON-16    	11419255	       103.4 ns/op	      96 B/op	       5 allocs/op
BenchmarkDecimal_UnmarshalJSON-16    	11392092	       103.3 ns/op	      96 B/op	       5 allocs/op
BenchmarkDecimal_UnmarshalJSON-16    	11341843	       104.6 ns/op	      96 B/op	       5 allocs/op
BenchmarkDecimal_UnmarshalJSON-16    	11605540	       103.0 ns/op	      96 B/op	       5 allocs/op
PASS
ok  	github.com/shopspring/decimal	12.861s
```

New:
```
goos: linux
goarch: amd64
pkg: github.com/shopspring/decimal
cpu: AMD Ryzen 7 7700X 8-Core Processor             
BenchmarkDecimal_UnmarshalJSON-16    	13650522	        83.84 ns/op	      72 B/op	       4 allocs/op
BenchmarkDecimal_UnmarshalJSON-16    	14697308	        80.16 ns/op	      72 B/op	       4 allocs/op
BenchmarkDecimal_UnmarshalJSON-16    	14545791	        80.81 ns/op	      72 B/op	       4 allocs/op
BenchmarkDecimal_UnmarshalJSON-16    	14889534	        79.66 ns/op	      72 B/op	       4 allocs/op
BenchmarkDecimal_UnmarshalJSON-16    	15066388	        79.93 ns/op	      72 B/op	       4 allocs/op
BenchmarkDecimal_UnmarshalJSON-16    	14768164	        80.08 ns/op	      72 B/op	       4 allocs/op
BenchmarkDecimal_UnmarshalJSON-16    	14964182	        80.74 ns/op	      72 B/op	       4 allocs/op
BenchmarkDecimal_UnmarshalJSON-16    	15048375	        80.77 ns/op	      72 B/op	       4 allocs/op
BenchmarkDecimal_UnmarshalJSON-16    	14638641	        80.14 ns/op	      72 B/op	       4 allocs/op
BenchmarkDecimal_UnmarshalJSON-16    	14878336	        80.23 ns/op	      72 B/op	       4 allocs/op
PASS
ok  	github.com/shopspring/decimal	12.701s
```

Benchstat comparison:
```
goos: linux
goarch: amd64
pkg: github.com/shopspring/decimal
cpu: AMD Ryzen 7 7700X 8-Core Processor             
                         │   old.txt    │               new.txt               │
                         │    sec/op    │   sec/op     vs base                │
Decimal_UnmarshalJSON-16   103.40n ± 1%   80.20n ± 1%  -22.44% (p=0.000 n=10)

                         │  old.txt   │              new.txt               │
                         │    B/op    │    B/op     vs base                │
Decimal_UnmarshalJSON-16   96.00 ± 0%   72.00 ± 0%  -25.00% (p=0.000 n=10)

                         │  old.txt   │              new.txt               │
                         │ allocs/op  │ allocs/op   vs base                │
Decimal_UnmarshalJSON-16   5.000 ± 0%   4.000 ± 0%  -20.00% (p=0.000 n=10)
```