### PR TITLE
fix: support negative precision in Truncate

### DIFF
--- a/decimal.go
+++ b/decimal.go
@@ -1753,13 +1753,16 @@ func (d Decimal) Ceil() Decimal {
 
 // Truncate truncates off digits from the number, without rounding.
 //
-// NOTE: precision is the last digit that will not be truncated (must be >= 0).
+// NOTE: precision is the last digit that will not be truncated.
+// Positive values truncate decimal places; negative values truncate
+// integer digits (e.g., -2 rounds to nearest hundred).
 //
 // Example:
 //
 //	decimal.NewFromString("123.456").Truncate(2).String() // "123.45"
+//	decimal.NewFromString("5432").Truncate(-2).String()   // "5400"
 func (d Decimal) Truncate(precision int32) Decimal {
-	if precision >= 0 && -precision > d.exp {
+	if -precision > d.exp {
 		return d.rescale(-precision)
 	}
 	return d


### PR DESCRIPTION
Fixes #406

## Problem

`Truncate` ignores negative precision values due to a `precision >= 0` guard:

```go
d := decimal.RequireFromString("5432")
d.Truncate(-2).String() // returns "5432" (unchanged)
// expected: "5400"
```

## Fix

Remove the `precision >= 0` check. The existing `rescale` logic already handles negative precision correctly — it truncates integer digits.

```go
decimal.RequireFromString("5432").Truncate(-2)  // "5400" ✅
decimal.RequireFromString("5432").Truncate(-1)  // "5430" ✅
decimal.RequireFromString("123.456").Truncate(2) // "123.45" ✅ (unchanged)
```

## Testing

All existing tests pass. The fix is a single-line change (removing `precision >= 0 &&`).