### PR TITLE
Update URLs to the Go website in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # decimal
 
 [![ci](https://github.com/shopspring/decimal/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/shopspring/decimal/actions/workflows/ci.yml)
-[![GoDoc](https://godoc.org/github.com/shopspring/decimal?status.svg)](https://godoc.org/github.com/shopspring/decimal) 
+[![Go Reference](https://pkg.go.dev/badge/github.com/shopspring/decimal.svg)](https://pkg.go.dev/github.com/shopspring/decimal)
 [![Go Report Card](https://goreportcard.com/badge/github.com/shopspring/decimal)](https://goreportcard.com/report/github.com/shopspring/decimal)
 
 Arbitrary-precision fixed-point decimal numbers in go.
@@ -26,7 +26,7 @@ Decimal library requires Go version `>=1.10`
 
 ## Documentation
 
-http://godoc.org/github.com/shopspring/decimal
+https://pkg.go.dev/github.com/shopspring/decimal
 
 
 ## Usage
@@ -82,7 +82,7 @@ Explore other alternatives to find the one that best fits your needs :)
 Because float64 (or any binary floating point type, actually) can't represent
 numbers such as `0.1` exactly.
 
-Consider this code: http://play.golang.org/p/TQBd4yJe6B You might expect that
+Consider this code: https://go.dev/play/p/TQBd4yJe6B You might expect that
 it prints out `10`, but it actually prints `9.999999999999831`. Over time,
 these small errors can really add up!
 
@@ -97,7 +97,7 @@ out, the string output has to stop somewhere (let's say it stops at 3 decimal
 digits, for simplicity), so you'll get 0.333, 0.333, and 0.333. But where did
 the other 0.001 go?
 
-Here's the above example as code: http://play.golang.org/p/lCZZs0w9KE
+Here's the above example as code: https://go.dev/play/p/lCZZs0w9KE
 
 With Decimal, the strings being printed out represent the number exactly. So,
 if you have `x = y = 1/3` (with precision 3), they will actually be equal to
@@ -122,7 +122,7 @@ modifies `a` and sets `z` as an alias for `a`, which they might not expect. It
 also modifies any other aliases to `a`.
 
 Here's an example of the subtle bugs you can introduce with big.Int's API:
-https://play.golang.org/p/x2R_78pa8r
+https://go.dev/play/p/x2R_78pa8r
 
 In contrast, it's difficult to make such mistakes with decimal. Decimals
 behave like other go numbers types: even though `a = b` will not deep copy


### PR DESCRIPTION
The same changes as in #264, but with conflicts resolved, since the author did not respond.

Closes #264

---

I learned about this project from the article https://socket.dev/blog/popular-go-decimal-library-typosquat-dns-backdoor