### PR TITLE
fix: NumDigits underreports for some exact powers of ten

### DIFF
--- a/decimal.go
+++ b/decimal.go
@@ -1256,13 +1256,26 @@ func (d Decimal) NumDigits() int {
 	v := d.getValue()
 	if v.IsInt64() {
 		i64 := v.Int64()
-		// restrict fast path to integers with exact conversion to float64
-		if i64 <= (1<<53) && i64 >= -(1<<53) {
-			if i64 == 0 {
-				return 1
-			}
-			return int(math.Log10(math.Abs(float64(i64)))) + 1
+		if i64 == 0 {
+			return 1
 		}
+		// Count digits via the underlying int64 instead of math.Log10,
+		// which rounds an exact 1eN like 1e15 down to 14.999... and would
+		// then under-report by one (see #420). Negation is safe because
+		// math.MinInt64 has IsInt64() true but its absolute value also
+		// needs counting; treat it explicitly.
+		if i64 == math.MinInt64 {
+			return 19
+		}
+		if i64 < 0 {
+			i64 = -i64
+		}
+		n := 0
+		for i64 > 0 {
+			n++
+			i64 /= 10
+		}
+		return n
 	}
 
 	estimatedNumDigits := int(float64(v.BitLen()) / math.Log2(10))

--- a/decimal_test.go
+++ b/decimal_test.go
@@ -3157,6 +3157,14 @@ func TestDecimal_NumDigits(t *testing.T) {
 		{"-5.2663117716", 11},
 		{"-26.1", 3},
 		{"", 1},
+		// Regression for #420: float64 math.Log10 rounds 1eN down to
+		// N-1 for some N (e.g. log10(1e15) == 14.999...), so the old
+		// fast path under-reported by one for exact-power coefficients.
+		{"1000000000000000", 16},
+		{"-1000000000000000", 16},
+		{"1000000000000000E20", 16},
+		{"9007199254740992", 16}, // 1<<53, the old fast-path boundary
+		{"-9007199254740992", 16},
 	} {
 		d, _ := NewFromString(testCase.Dec)
 


### PR DESCRIPTION
From the reporter in #420:

```
100000000000000E20:  ... 15 15   (ok: 15 digits)
1000000000000000E20: ... 16 15   (wrong: 16 digits, NumDigits says 15)
10000000000000000E20: ... 17 17  (ok: 17 digits)
```

The fast path returns `int(math.Log10(math.Abs(float64(i64)))) + 1`, and `math.Log10` of an exact power of ten doesn't always round to the exact integer. On my machine:

```
log10(1e14) = 14.0
log10(1e15) = 14.99999999999999822364
log10(1e16) = 16.0
```

So 1e15 takes the wrong branch and `int(...) + 1` returns 15 instead of 16. Same shape at 1e24, 1e28, and other powers where the float64 representation drifts down.

Count digits via plain int64 division instead. No floats, no estimate. The `big.Int` slow path is unchanged.

Regression cases added to `TestDecimal_NumDigits` cover `1e15` directly, with sign and scientific-notation variants, plus `1<<53` (the boundary of the old fast path). Fails on master, passes here. `go test ./...` is clean.

Fixes #420.
