### PR TITLE
fix: normalize exponent in rounding functions and support negative precision in Truncate

### DIFF
--- a/decimal.go
+++ b/decimal.go
@@ -1582,7 +1582,7 @@ func (d Decimal) RoundCeil(places int32) Decimal {
 
 	rescaled := d.rescale(-places)
 	if d.Equal(rescaled) {
-		return d
+		return rescaled
 	}
 
 	if d.getValue().Sign() > 0 {
@@ -1607,7 +1607,7 @@ func (d Decimal) RoundFloor(places int32) Decimal {
 
 	rescaled := d.rescale(-places)
 	if d.Equal(rescaled) {
-		return d
+		return rescaled
 	}
 
 	if d.getValue().Sign() < 0 {
@@ -1632,7 +1632,7 @@ func (d Decimal) RoundUp(places int32) Decimal {
 
 	rescaled := d.rescale(-places)
 	if d.Equal(rescaled) {
-		return d
+		return rescaled
 	}
 
 	if d.getValue().Sign() > 0 {
@@ -1659,7 +1659,7 @@ func (d Decimal) RoundDown(places int32) Decimal {
 
 	rescaled := d.rescale(-places)
 	if d.Equal(rescaled) {
-		return d
+		return rescaled
 	}
 	return rescaled
 }
@@ -1766,13 +1766,17 @@ func (d Decimal) Ceil() Decimal {
 
 // Truncate truncates off digits from the number, without rounding.
 //
-// NOTE: precision is the last digit that will not be truncated (must be >= 0).
+// If precision >= 0, it specifies the number of decimal places to keep.
+// If precision < 0, it truncates the integer part to the nearest 10^(-precision)
+// towards zero.
 //
 // Example:
 //
-//	decimal.NewFromString("123.456").Truncate(2).String() // "123.45"
+//	decimal.NewFromString("123.456").Truncate(2).String()  // "123.45"
+//	decimal.NewFromString("5432").Truncate(-2).String()    // "5400"
+//	decimal.NewFromString("-5432").Truncate(-2).String()   // "-5400"
 func (d Decimal) Truncate(precision int32) Decimal {
-	if precision >= 0 && -precision > d.exp {
+	if -precision > d.exp {
 		return d.rescale(-precision)
 	}
 	return d

--- a/decimal_test.go
+++ b/decimal_test.go
@@ -3970,3 +3970,99 @@ func ExampleNewFromFloat() {
 	//0.123123123123123
 	//-10000000000000
 }
+
+// TestTruncateNegativePrecision verifies that Truncate correctly handles
+// negative precision values, truncating the integer part towards zero.
+func TestTruncateNegativePrecision(t *testing.T) {
+	type testCase struct {
+		input     string
+		places    int32
+		want      string
+		wantExp   int32
+	}
+	tests := []testCase{
+		// negative precision: truncate integer part
+		{"5432", -2, "5400", 2},
+		{"-5432", -2, "-5400", 2},
+		{"5499", -2, "5400", 2},
+		{"5500", -2, "5500", 2},
+		{"5501", -2, "5500", 2},
+		{"999", -3, "0", 3},
+		{"1000", -3, "1000", 3},
+		{"1001", -3, "1000", 3},
+		{"-999", -3, "0", 3},
+		{"-1000", -3, "-1000", 3},
+		// positive precision still works as before
+		{"123.456", 2, "123.45", -2},
+		{"123.456", 0, "123", 0},
+		{"123.456", 5, "123.456", -3},
+	}
+
+	for _, tc := range tests {
+		d := RequireFromString(tc.input)
+		got := d.Truncate(tc.places)
+		if got.String() != tc.want {
+			t.Errorf("(%s).Truncate(%d): got %s, want %s", tc.input, tc.places, got.String(), tc.want)
+		}
+		if got.exp != tc.wantExp {
+			t.Errorf("(%s).Truncate(%d): got exponent %d, want %d", tc.input, tc.places, got.exp, tc.wantExp)
+		}
+	}
+}
+
+// TestRoundingExponentNormalization verifies that RoundUp, RoundDown,
+// RoundCeil, and RoundFloor return a result with the exponent normalized
+// to the requested number of places, even when the value is already exact.
+func TestRoundingExponentNormalization(t *testing.T) {
+	type testCase struct {
+		fn      string
+		input   string
+		places  int32
+		wantStr string
+		wantExp int32
+	}
+
+	tests := []testCase{
+		// RoundUp
+		{"RoundUp", "100.0", 0, "100", 0},
+		{"RoundUp", "100.00", 0, "100", 0},
+		{"RoundUp", "3.14", 2, "3.14", -2},
+		{"RoundUp", "500", -2, "500", 2},
+		// RoundDown
+		{"RoundDown", "100.0", 0, "100", 0},
+		{"RoundDown", "100.00", 0, "100", 0},
+		{"RoundDown", "3.14", 2, "3.14", -2},
+		{"RoundDown", "500", -2, "500", 2},
+		// RoundFloor
+		{"RoundFloor", "100.0", 0, "100", 0},
+		{"RoundFloor", "100.00", 0, "100", 0},
+		{"RoundFloor", "-100.0", 0, "-100", 0},
+		{"RoundFloor", "500", -2, "500", 2},
+		// RoundCeil
+		{"RoundCeil", "100.0", 0, "100", 0},
+		{"RoundCeil", "100.00", 0, "100", 0},
+		{"RoundCeil", "-100.0", 0, "-100", 0},
+		{"RoundCeil", "500", -2, "500", 2},
+	}
+
+	for _, tc := range tests {
+		d := RequireFromString(tc.input)
+		var got Decimal
+		switch tc.fn {
+		case "RoundUp":
+			got = d.RoundUp(tc.places)
+		case "RoundDown":
+			got = d.RoundDown(tc.places)
+		case "RoundFloor":
+			got = d.RoundFloor(tc.places)
+		case "RoundCeil":
+			got = d.RoundCeil(tc.places)
+		}
+		if got.String() != tc.wantStr {
+			t.Errorf("(%s).%s(%d): got %s, want %s", tc.input, tc.fn, tc.places, got.String(), tc.wantStr)
+		}
+		if got.exp != tc.wantExp {
+			t.Errorf("(%s).%s(%d): got exponent %d, want %d", tc.input, tc.fn, tc.places, got.exp, tc.wantExp)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

This PR fixes two related bugs in decimal rounding and truncation:

1. `RoundUp`, `RoundDown`, `RoundFloor`, and `RoundCeil` returned the original decimal (with its original exponent) when the value was already exact at the requested precision, causing the result to carry a stale exponent that did not match the requested places. (Fixes #390)

2. `Truncate` rejected negative precision values due to a `precision >= 0` guard, silently returning the input unchanged. Negative precision should truncate the integer part toward zero — for example `(5432).Truncate(-2)` should return `5400`. (Fixes #406)

## Changes

**`decimal.go`**

- `RoundCeil`: return `rescaled` (not `d`) when the value is already exact at the target precision
- `RoundFloor`: same
- `RoundUp`: same
- `RoundDown`: same
- `Truncate`: remove the `precision >= 0` guard; `rescale` uses `big.Int.Quo` (truncates toward zero) so negative precision works correctly without additional adjustment; update doc comment and examples

**`decimal_test.go`**

- `TestTruncateNegativePrecision`: table-driven tests for `Truncate` with negative and positive precision, checking both value and exponent
- `TestRoundingExponentNormalization`: table-driven tests for all four rounding functions verifying that the returned exponent matches the requested places when the value is already exact

## Testing

```
$ go test ./...
ok  github.com/shopspring/decimal  8.2s
```

### Example: exponent normalization (issue #390)

Before this fix:
```go
d, _ := decimal.NewFromString("100.0")
r := d.RoundUp(0)
r.Exponent()                     // -1  (wrong, should be 0)
r.StringFixedBank(-r.Exponent()) // "100.0"  (wrong)
```

After:
```go
d, _ := decimal.NewFromString("100.0")
r := d.RoundUp(0)
r.Exponent()                     // 0
r.StringFixedBank(-r.Exponent()) // "100"
```

The same fix applies to `RoundDown`, `RoundFloor`, and `RoundCeil`.

### Example: negative precision in Truncate (issue #406)

Before:
```go
decimal.RequireFromString("5432").Truncate(-2).String() // "5432"  (unchanged, wrong)
```

After:
```go
decimal.RequireFromString("5432").Truncate(-2).String()  // "5400"
decimal.RequireFromString("-5432").Truncate(-2).String() // "-5400"
decimal.RequireFromString("5499").Truncate(-2).String()  // "5400"
decimal.RequireFromString("5500").Truncate(-2).String()  // "5500"
```