### PR TITLE
feat: add ExpMaxLimit and ExpMinLimit to prevent OOM / DoS via huge exponents

### DIFF
--- a/decimal.go
+++ b/decimal.go
@@ -78,6 +78,14 @@ var TrimTrailingZeros = true
 // digits are unknown. With this set to true, that number would be expressed as "1.2E3" instead.
 var UseScientificNotation = false
 
+// ExpMaxLimit limits the maximum allowed exponent when parsing or operating on decimals.
+// Extremely large exponents can cause memory leaks/OOM panics due to how math/big.Int allocates memory.
+// By default, this is set to math.MaxInt32 for backwards compatibility, but it's strongly recommended
+// to set this to a lower bound (e.g., 10000) for APIs that accept user input.
+var ExpMaxLimit = int32(math.MaxInt32)
+
+// ExpMinLimit limits the minimum allowed exponent when parsing decimals.
+var ExpMinLimit = int32(math.MinInt32)
 // ExpMaxIterations specifies the maximum number of iterations needed to calculate
 // precise natural exponent value using ExpHullAbrham method.
 var ExpMaxIterations = 1000
@@ -267,6 +275,10 @@ func NewFromString(value string) (Decimal, error) {
 	if exp < math.MinInt32 || exp > math.MaxInt32 {
 		// NOTE(vadim): I doubt a string could realistically be this long
 		return Decimal{}, fmt.Errorf("can't convert %s to decimal: fractional part too long", originalInput)
+	}
+
+	if exp < int64(ExpMinLimit) || exp > int64(ExpMaxLimit) {
+		return Decimal{}, fmt.Errorf("can't convert %s to decimal: exponent out of bounds", originalInput)
 	}
 
 	return Decimal{

--- a/decimal_test.go
+++ b/decimal_test.go
@@ -3970,3 +3970,33 @@ func ExampleNewFromFloat() {
 	//0.123123123123123
 	//-10000000000000
 }
+
+func TestNewFromStringExpLimit(t *testing.T) {
+	oldMax := ExpMaxLimit
+	oldMin := ExpMinLimit
+	defer func() {
+		ExpMaxLimit = oldMax
+		ExpMinLimit = oldMin
+	}()
+
+	ExpMaxLimit = 10000
+	ExpMinLimit = -10000
+
+	// Should pass
+	_, err := NewFromString("1e10000")
+	if err != nil {
+		t.Fatalf("expected 1e10000 to pass, got %v", err)
+	}
+
+	// Should fail (exceeds max)
+	_, err = NewFromString("1e10001")
+	if err == nil {
+		t.Fatal("expected 1e10001 to fail")
+	}
+
+	// Should fail (exceeds min)
+	_, err = NewFromString("1e-10001")
+	if err == nil {
+		t.Fatal("expected 1e-10001 to fail")
+	}
+}


### PR DESCRIPTION
## Description

This PR introduces global `ExpMaxLimit` and `ExpMinLimit` variables (defaulting to `math.MaxInt32` and `math.MinInt32` to preserve backward compatibility).

### The Vulnerability
Currently, `shopspring/decimal` is vulnerable to Denial of Service (DoS) attacks via memory exhaustion and CPU starvation. If an attacker submits a JSON payload containing an extremely large scientific exponent (e.g., `{"value": "1E2000000"}`), `NewFromString` parses the exponent successfully into its `int32` representation.

While parsing is fast, any subsequent operation that relies on expanding or comparing this value (e.g., `.String()`, `.Add()`, `.Cmp()`) forces the underlying `math/big.Int` to allocate huge amounts of memory and stall the CPU.
For example, parsing `"1E1000000000"` (an exponent of 1 billion) causes the allocation of a single `big.Int` containing $\approx 3.32$ billion bits, instantly consuming **~415 MB of RAM**. A web server receiving just a few concurrent requests of this nature will rapidly exhaust memory and crash.

### The Fix
This adds two exported global limits, `decimal.ExpMaxLimit` and `decimal.ExpMinLimit`, checking them inside `NewFromString`. 
Users running web services can now opt-in to bounded exponent parsing (e.g., `decimal.ExpMaxLimit = 100000`) globally on initialization, preventing OOM panics at the unmarshaling boundary without requiring wrapper structs.
