### PR TITLE
fix: accept Unicode minus in NewFromString

### DIFF
--- a/decimal.go
+++ b/decimal.go
@@ -202,6 +202,9 @@ func NewFromString(value string) (Decimal, error) {
 	var intString string
 	var exp int64
 
+	// Accept Unicode minus sign (U+2212) in addition to ASCII '-'.
+	value = strings.Replace(value, "\u2212", "-", -1)
+
 	// Check if number is using scientific notation and find dots
 	eIndex := -1
 	pIndex := -1

--- a/decimal_test.go
+++ b/decimal_test.go
@@ -306,6 +306,26 @@ func TestFloat64(t *testing.T) {
 	}
 }
 
+func TestNewFromStringUnicodeMinus(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"\u2212123.45", "-123.45"},
+		{"\u2212.5", "-0.5"},
+		{"1e\u22122", "0.01"},
+	}
+	for _, tc := range cases {
+		d, err := NewFromString(tc.in)
+		if err != nil {
+			t.Errorf("NewFromString(%q) unexpected error: %v", tc.in, err)
+			continue
+		}
+		if d.String() != tc.want {
+			t.Errorf("NewFromString(%q) = %q, want %q", tc.in, d.String(), tc.want)
+		}
+	}
+}
+
 func TestNewFromStringErrs(t *testing.T) {
 	tests := []string{
 		"",


### PR DESCRIPTION
Some locales and copy-paste sources use U+2212 (−) instead of ASCII '-'. Normalize it before parsing so NewFromString accepts both.

Closes #318