### PR TITLE
NewFromFloat and NewFromFloat32 performance improvements

### DIFF
--- a/decimal-go.go
+++ b/decimal-go.go
@@ -2,6 +2,13 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build !go1.13
+// +build !go1.13
+
+// This file is only built for Go versions older than 1.13. From Go 1.13 on,
+// strconv's own shortest-float conversion is correct (golang/go#29491) and
+// newFromFloat delegates to it instead. See newfromfloat_go113.go.
+
 // Multiprecision decimal numbers.
 // For floating-point formatting only; not general purpose.
 // Only operations are assign and (binary) left/right shift.

--- a/decimal.go
+++ b/decimal.go
@@ -329,7 +329,7 @@ func NewFromFloat(value float64) Decimal {
 	if value == 0 {
 		return New(0, 0)
 	}
-	return newFromFloat(value, math.Float64bits(value), &float64info)
+	return newFromFloat(value, 64)
 }
 
 // NewFromFloat32 converts a float32 to Decimal.
@@ -346,55 +346,7 @@ func NewFromFloat32(value float32) Decimal {
 	if value == 0 {
 		return New(0, 0)
 	}
-	// XOR is workaround for https://github.com/golang/go/issues/26285
-	a := math.Float32bits(value) ^ 0x80808080
-	return newFromFloat(float64(value), uint64(a)^0x80808080, &float32info)
-}
-
-func newFromFloat(val float64, bits uint64, flt *floatInfo) Decimal {
-	if math.IsNaN(val) || math.IsInf(val, 0) {
-		panic(fmt.Sprintf("Cannot create a Decimal from %v", val))
-	}
-	exp := int(bits>>flt.mantbits) & (1<<flt.expbits - 1)
-	mant := bits & (uint64(1)<<flt.mantbits - 1)
-
-	switch exp {
-	case 0:
-		// denormalized
-		exp++
-
-	default:
-		// add implicit top bit
-		mant |= uint64(1) << flt.mantbits
-	}
-	exp += flt.bias
-
-	var d decimal
-	d.Assign(mant)
-	d.Shift(exp - int(flt.mantbits))
-	d.neg = bits>>(flt.expbits+flt.mantbits) != 0
-
-	roundShortest(&d, mant, exp, flt)
-	// If less than 19 digits, we can do calculation in an int64.
-	if d.nd < 19 {
-		tmp := int64(0)
-		m := int64(1)
-		for i := d.nd - 1; i >= 0; i-- {
-			tmp += m * int64(d.d[i]-'0')
-			m *= 10
-		}
-		if d.neg {
-			tmp *= -1
-		}
-		return Decimal{value: big.NewInt(tmp), exp: int32(d.dp) - int32(d.nd)}
-	}
-	dValue := new(big.Int)
-	dValue, ok := dValue.SetString(string(d.d[:d.nd]), 10)
-	if ok {
-		return Decimal{value: dValue, exp: int32(d.dp) - int32(d.nd)}
-	}
-
-	return NewFromFloatWithExponent(val, int32(d.dp)-int32(d.nd))
+	return newFromFloat(float64(value), 32)
 }
 
 // NewFromFloatWithExponent converts a float64 to Decimal, with an arbitrary

--- a/newfromfloat_go113.go
+++ b/newfromfloat_go113.go
@@ -1,0 +1,70 @@
+//go:build go1.13
+// +build go1.13
+
+package decimal
+
+import (
+	"fmt"
+	"math"
+	"math/big"
+	"strconv"
+)
+
+// newFromFloat converts val to a Decimal holding the shortest decimal digit
+// string that round-trips back to val when parsed at the given bit size.
+//
+// strconv already computes exactly that string, so we ask it for the value in
+// 'e' format with precision -1 and read the digits back out. The 'e' layout is
+// [-]d[.ddd]e±dd, which is bounded (at most 24 bytes) and trivial to scan,
+// unlike 'f' which can run to over 750 bytes for extreme exponents.
+func newFromFloat(val float64, bitSize int) Decimal {
+	if math.IsNaN(val) || math.IsInf(val, 0) {
+		panic(fmt.Sprintf("Cannot create a Decimal from %v", val))
+	}
+
+	var buf [32]byte
+	b := strconv.AppendFloat(buf[:0], val, 'e', -1, bitSize)
+
+	neg := b[0] == '-'
+	if neg {
+		b = b[1:]
+	}
+
+	// Split the significand from the exponent. b always contains an 'e'.
+	var i int
+	for b[i] != 'e' {
+		i++
+	}
+	digits, expDigits := b[:i], b[i+1:]
+
+	// The shortest round-trip form has at most 17 significant digits for a
+	// float64 and 9 for a float32, so the significand always fits in an int64.
+	var mant int64
+	nd := 0
+	for _, c := range digits {
+		if c == '.' {
+			continue
+		}
+		mant = mant*10 + int64(c-'0')
+		nd++
+	}
+	if neg {
+		mant = -mant
+	}
+
+	esign := 1
+	switch expDigits[0] {
+	case '-':
+		esign = -1
+		expDigits = expDigits[1:]
+	case '+':
+		expDigits = expDigits[1:]
+	}
+	e := 0
+	for _, c := range expDigits {
+		e = e*10 + int(c-'0')
+	}
+
+	// digits is d.ddd, i.e. the significand scaled by 10^(nd-1).
+	return Decimal{value: big.NewInt(mant), exp: int32(esign*e - nd + 1)}
+}

--- a/newfromfloat_go113_test.go
+++ b/newfromfloat_go113_test.go
@@ -1,0 +1,114 @@
+//go:build go1.13
+// +build go1.13
+
+package decimal
+
+import (
+	"math"
+	"math/rand"
+	"strconv"
+	"testing"
+)
+
+// TestNewFromFloatShortestRoundTrip pins the contract of NewFromFloat and
+// NewFromFloat32: the result is the shortest decimal that parses back to the
+// original float. It covers the exponent and significand shapes a
+// shortest-representation conversion has to get right, namely subnormals,
+// three-digit exponents, single-digit significands and the range extremes.
+//
+// It is gated on Go 1.13 because before that strconv itself could return a
+// shortest form that was not the nearest one (golang/go#29491), which would make
+// the reference value below wrong rather than the conversion under test.
+func TestNewFromFloatShortestRoundTrip(t *testing.T) {
+	f64 := []float64{
+		1, -1, 0.1, -0.1, 0.5, 2.5, 100, 123.456,
+		1e15, 1e16, 1e17, 1e21, 1e22, 1e23, 9007199254740992,
+		1e-100, 1e100, 1e-300, 1e300,
+		math.MaxFloat64, -math.MaxFloat64,
+		math.SmallestNonzeroFloat64, -math.SmallestNonzeroFloat64,
+		math.Pi, math.E,
+	}
+	// Every power of two, which sweeps the whole exponent range including the
+	// subnormals, plus both neighbours of every value collected so far.
+	for e := -1074; e <= 1023; e++ {
+		f64 = append(f64, math.Ldexp(1, e))
+	}
+	for _, f := range append([]float64{}, f64...) {
+		f64 = append(f64, math.Nextafter(f, math.Inf(1)), math.Nextafter(f, math.Inf(-1)))
+	}
+
+	for _, f := range f64 {
+		if f == 0 || math.IsInf(f, 0) {
+			continue
+		}
+		want, err := NewFromString(strconv.FormatFloat(f, 'f', -1, 64))
+		if err != nil {
+			t.Fatalf("NewFromString(%v): %v", f, err)
+		}
+		got := NewFromFloat(f)
+		if !got.Equal(want) {
+			t.Errorf("NewFromFloat(%v) = %s (%s, %d), want %s (%s, %d)",
+				f, got, got.value, got.exp, want, want.value, want.exp)
+		}
+		if back, _ := got.Float64(); back != f {
+			t.Errorf("NewFromFloat(%v).Float64() = %v, does not round-trip", f, back)
+		}
+	}
+
+	f32 := []float32{
+		1, -1, 0.1, -0.1, 100, 123.456,
+		math.MaxFloat32, -math.MaxFloat32,
+		math.SmallestNonzeroFloat32, -math.SmallestNonzeroFloat32,
+	}
+	for e := -149; e <= 127; e++ {
+		f32 = append(f32, float32(math.Ldexp(1, e)))
+	}
+	for _, f := range f32 {
+		if f == 0 {
+			continue
+		}
+		want, err := NewFromString(strconv.FormatFloat(float64(f), 'f', -1, 32))
+		if err != nil {
+			t.Fatalf("NewFromString(%v): %v", f, err)
+		}
+		got := NewFromFloat32(f)
+		if !got.Equal(want) {
+			t.Errorf("NewFromFloat32(%v) = %s (%s, %d), want %s (%s, %d)",
+				f, got, got.value, got.exp, want, want.value, want.exp)
+		}
+	}
+}
+
+// TestNewFromFloatRandomRoundTrip sweeps random bit patterns, which puts a
+// meaningful share of subnormals and extreme exponents through the conversion.
+func TestNewFromFloatRandomRoundTrip(t *testing.T) {
+	rng := rand.New(rand.NewSource(0xdead1337))
+	for i := 0; i < 200000; i++ {
+		f := math.Float64frombits(rng.Uint64())
+		if f == 0 || math.IsNaN(f) || math.IsInf(f, 0) {
+			continue
+		}
+		want, err := NewFromString(strconv.FormatFloat(f, 'f', -1, 64))
+		if err != nil {
+			t.Fatalf("NewFromString(%v): %v", f, err)
+		}
+		if got := NewFromFloat(f); !got.Equal(want) {
+			t.Fatalf("NewFromFloat(%v) = %s (%s, %d), want %s (%s, %d)",
+				f, got, got.value, got.exp, want, want.value, want.exp)
+		}
+	}
+	for i := 0; i < 200000; i++ {
+		f := math.Float32frombits(rng.Uint32())
+		if f == 0 || math.IsNaN(float64(f)) || math.IsInf(float64(f), 0) {
+			continue
+		}
+		want, err := NewFromString(strconv.FormatFloat(float64(f), 'f', -1, 32))
+		if err != nil {
+			t.Fatalf("NewFromString(%v): %v", f, err)
+		}
+		if got := NewFromFloat32(f); !got.Equal(want) {
+			t.Fatalf("NewFromFloat32(%v) = %s (%s, %d), want %s (%s, %d)",
+				f, got, got.value, got.exp, want, want.value, want.exp)
+		}
+	}
+}

--- a/newfromfloat_legacy.go
+++ b/newfromfloat_legacy.go
@@ -1,0 +1,76 @@
+//go:build !go1.13
+// +build !go1.13
+
+package decimal
+
+import (
+	"fmt"
+	"math"
+	"math/big"
+)
+
+// newFromFloat converts val to a Decimal holding the shortest decimal digit
+// string that round-trips back to val when parsed at the given bit size.
+//
+// This is the pre-Go 1.13 implementation: it computes the shortest form itself,
+// using the vendored copy of strconv's multiprecision decimal (decimal-go.go and
+// rounding.go), because strconv.FormatFloat could return a shortest form that is
+// not the nearest one before Go 1.13 (golang/go#29491).
+func newFromFloat(val float64, bitSize int) Decimal {
+	if math.IsNaN(val) || math.IsInf(val, 0) {
+		panic(fmt.Sprintf("Cannot create a Decimal from %v", val))
+	}
+
+	var bits uint64
+	var flt *floatInfo
+	if bitSize == 32 {
+		// XOR is workaround for https://github.com/golang/go/issues/26285
+		a := math.Float32bits(float32(val)) ^ 0x80808080
+		bits = uint64(a) ^ 0x80808080
+		flt = &float32info
+	} else {
+		bits = math.Float64bits(val)
+		flt = &float64info
+	}
+
+	exp := int(bits>>flt.mantbits) & (1<<flt.expbits - 1)
+	mant := bits & (uint64(1)<<flt.mantbits - 1)
+
+	switch exp {
+	case 0:
+		// denormalized
+		exp++
+
+	default:
+		// add implicit top bit
+		mant |= uint64(1) << flt.mantbits
+	}
+	exp += flt.bias
+
+	var d decimal
+	d.Assign(mant)
+	d.Shift(exp - int(flt.mantbits))
+	d.neg = bits>>(flt.expbits+flt.mantbits) != 0
+
+	roundShortest(&d, mant, exp, flt)
+	// If less than 19 digits, we can do calculation in an int64.
+	if d.nd < 19 {
+		tmp := int64(0)
+		m := int64(1)
+		for i := d.nd - 1; i >= 0; i-- {
+			tmp += m * int64(d.d[i]-'0')
+			m *= 10
+		}
+		if d.neg {
+			tmp *= -1
+		}
+		return Decimal{value: big.NewInt(tmp), exp: int32(d.dp) - int32(d.nd)}
+	}
+	dValue := new(big.Int)
+	dValue, ok := dValue.SetString(string(d.d[:d.nd]), 10)
+	if ok {
+		return Decimal{value: dValue, exp: int32(d.dp) - int32(d.nd)}
+	}
+
+	return NewFromFloatWithExponent(val, int32(d.dp)-int32(d.nd))
+}

--- a/rounding.go
+++ b/rounding.go
@@ -2,6 +2,13 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build !go1.13
+// +build !go1.13
+
+// This file is only built for Go versions older than 1.13. From Go 1.13 on,
+// strconv's own shortest-float conversion is correct (golang/go#29491) and
+// newFromFloat delegates to it instead. See newfromfloat_go113.go.
+
 // Multiprecision decimal numbers.
 // For floating-point formatting only; not general purpose.
 // Only operations are assign and (binary) left/right shift.


### PR DESCRIPTION
## Summary

`decimal-go.go` is a copy of `strconv/decimal.go` from 2009. `NewFromFloat` and `NewFromFloat32` use this copy to find the shortest decimal string for a float. The Go standard library no longer uses this code. Go 1.27 replaced it with a new algorithm. The vendored copy does not get these improvements.

This PR removes the vendored path from `NewFromFloat` and `NewFromFloat32`. The functions now call `strconv.FormatFloat(v, 'e', -1, bitSize)`. This call returns the shortest decimal string that round-trips to the original float. The function then parses the digits and the exponent from that string. The exponent is parsed with a small loop. `strconv.Atoi` would need a `string(byteslice)` conversion and one more allocation.

The output does not change. The shortest round-trip contract of `NewFromFloat` stays the same. See #411 and #418 for the current discussion about this contract. This PR does not change the contract. It only makes the same output faster.

## Benchmarks

Ryzen 9 5900X, Linux, `-benchtime 2s -count 5`, median. The machine was idle.

| Benchmark | Go 1.22 before | Go 1.22 after | Go 1.27 before | Go 1.27 after |
|---|---|---|---|---|
| `NewFromFloat` | 366.4 ns | 167.7 ns | 332.2 ns | **93.7 ns** |
| `NewFromFloat32` | 271.8 ns | 130.0 ns | 241.7 ns | **91.9 ns** |

The change in Go 1.27 is larger because Go 1.27 replaced the float conversion code in `strconv` with the new uscale algorithm. The vendored copy in this repo could not benefit from that change. This PR connects `NewFromFloat` to `strconv` again.

Both versions allocate the same: 2 allocs / 40 B. Both allocations come from the `*big.Int` in `Decimal.value`. This is a property of the `Decimal` type, not of this change.

## Correctness

I compared the old implementation with the new one on the same inputs. The functions must return the same `(value, exp)` pair.

- float32: all 4,278,190,078 non-zero finite bit patterns. Exhaustive, not a sample. Mismatches: 0.
- float64: 578,922,574 random and structured bit patterns. This covers subnormals, extreme exponents, powers of two with their neighbors (exponents -1074 to 1023), powers of ten (exponents -340 to 308), and dense scans of low subnormals. Mismatches: 0.

I ran the comparison on Go 1.13 (the first version that uses the new path) and on Go 1.27. Both runs show 0 mismatches.

The test suite passes on six toolchains:

```
go1.10.8   ok   (legacy path)
go1.11.13  ok   (legacy path)
go1.12.17  ok   (legacy path)
go1.13.15  ok   (new path)
go1.22.12  ok   (new path)
go1.27.0   ok   (new path)
```

The PR adds two tests in `newfromfloat_go113_test.go`:

- `TestNewFromFloatShortestRoundTrip`. The result must equal `NewFromString(strconv.FormatFloat(f, 'f', -1, bitSize))`, and `Float64()` must return the original float. The test covers powers of two with neighbors, three-digit exponents, and range extremes.
- `TestNewFromFloatRandomRoundTrip`. 200,000 random float64 bit patterns and 200,000 random float32 bit patterns.

These tests use `strconv` as the reference. On Go 1.12 and older, `strconv` itself gives wrong answers in rare cases. See the next section. This is why the new tests are gated with `//go:build go1.13`.

## Why build tags, not a go.mod bump: golang/go#29491

Before Go 1.13, the shortest-decimal code in `strconv` sometimes picked the candidate that is farther from the exact value. Two test cases in `decimal_test.go` exist for this reason. They are marked with a comment about issue golang/go#29491. The vendored slow path gives the correct answer there. `strconv.FormatFloat` with `-1` gives the wrong answer on Go 1.10, 1.11, and 1.12. Go 1.13 fixed this. I verified the boundary on all three old toolchains.

Example from the probe:

```
498484681984085570  (bits 0x439babe4b56e8a39)
  exact value:        498484681984085568
  Go 1.10-1.12:      4.9848468198408556e+17   distance 8    (wrong)
  Go 1.13 and later: 4.9848468198408557e+17   distance 2    (correct)
```

For this reason the old implementation moves to `newfromfloat_legacy.go` behind `//go:build !go1.13`. `decimal-go.go` and `rounding.go` get a `!go1.13` build tag too. Their content does not change. Files with a `go1.13` tag do not need their content.

The go.mod version stays at 1.10. I read the discussions in #305, #353, and #361. The project keeps the oldest Go version that it can support. The build tags keep that property. The CI matrix already runs 1.10.x, and the tests pass there through the legacy path.

When the go.mod minimum reaches 1.13 in the future, the files `decimal-go.go`, `rounding.go`, and `newfromfloat_legacy.go` can be deleted. That removes 575 lines.

## File changes

```
decimal.go                  -50   two call sites remain: newFromFloat(value, 64) / (float64(value), 32)
newfromfloat_go113.go       +70   //go:build go1.13    new strconv path
newfromfloat_legacy.go      +76   //go:build !go1.13   old newFromFloat, moved
decimal-go.go               +7    //go:build !go1.13   build tag only, no content change
rounding.go                 +7    //go:build !go1.13   build tag only, no content change
newfromfloat_go113_test.go  +114  //go:build go1.13    new tests
```

Each build tag carries both `//go:build` and the old `// +build` form. `decimal_go124_test.go` already uses this pattern.

`newfromfloat_legacy.go` keeps the `math.Float32bits(value) ^ 0x80808080` workaround for golang/go#26285. The behavior on Go 1.12 and older stays exactly the same as on master.

## Background

I wrote a detailed analysis of the Go 1.27 `strconv` rewrite and its effect on libraries that vendor the old code (in Chinese): https://www.omegaatt.com/blogs/develop/2026/golang_unrounded_scaling/

Related issues: #161 (rounding bug in the vendored `roundShortest`) is another cost of keeping the vendored copy.
